### PR TITLE
Autoinstall.sh update

### DIFF
--- a/scripts/autoinstall.sh
+++ b/scripts/autoinstall.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Made by @legitbox, this creature will auto install the endstone server software depending on what server os you are using
-# WARNING! Doesn't support any distros that are based on the supported oses
 
 
 # Define the virtual environment directory

--- a/scripts/autoinstall.sh
+++ b/scripts/autoinstall.sh
@@ -46,21 +46,21 @@ setup_arch() {
 # Detect the Linux distribution
 if [ -f /etc/os-release ]; then
     . /etc/os-release
-    case $ID in
-        ubuntu|debian)
+    case $ID_LIKE in
+        *debian*|*ubuntu*)
             echo "Detected Debian/Ubuntu based system."
             setup_debian
             ;;
-        fedora)
+        *fedora*)
             echo "Detected Fedora based system."
             setup_fedora
             ;;
-        arch)
+        *arch*)
             echo "Detected Arch based system."
             setup_arch
             ;;
         *)
-            echo "Unsupported Linux distribution: $ID"
+            echo "Unsupported Linux distribution: $ID_LIKE"
             exit 1
             ;;
     esac
@@ -85,3 +85,4 @@ pip install endstone
 
 # Run 'endstone'
 endstone
+


### PR DESCRIPTION
Changed it to use ID_LIKE instead of ID, that lets other distros that are based on other mainline os'ses to still autoinstall endstone