### PR TITLE
fix spelling of recommended

### DIFF
--- a/docs/tutorials/create-your-first-plugin.md
+++ b/docs/tutorials/create-your-first-plugin.md
@@ -54,7 +54,7 @@ toc_depth: 2
 
     !!! tip
         Endstone server requires its plugins to be installed in the same Python environment. A virtual environment is
-        **strongly recommanded**.
+        **strongly recommended**.
 
     ### Check your dependencies
 


### PR DESCRIPTION
I fixed the spelling of recommended (it was reccomanded) in the Python guide