### PR TITLE
Fix Expected Lite Dependency Tag

### DIFF
--- a/cmake/EndstoneHeaders.cmake
+++ b/cmake/EndstoneHeaders.cmake
@@ -50,7 +50,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         expected-lite
         GIT_REPOSITORY https://github.com/martinmoene/expected-lite.git
-        GIT_TAG 0.8.0
+        GIT_TAG v0.8.0
 )
 FetchContent_MakeAvailable(fmt expected-lite)
 


### PR DESCRIPTION
For some reason they seem to have changed the tag on their releases- they added a v. No idea why. 

Check yourself here: https://github.com/martinmoene/expected-lite.git

Could not compile until this was changed.