### PR TITLE
Adjust plugin loading logic, fix #98

### DIFF
--- a/src/endstone_core/plugin/plugin_manager.cpp
+++ b/src/endstone_core/plugin/plugin_manager.cpp
@@ -87,11 +87,15 @@ Plugin *EndstonePluginManager::loadPlugin(std::string file)
 {
     Plugin *result = nullptr;
     for (const auto &loader : plugin_loaders_) {
-        if (auto *plugin = loader->loadPlugin(file); plugin) {
-            if (initPlugin(*plugin, *loader, fs::path(file).parent_path())) {
-                result = plugin;
+        for (const auto &pattern : loader->getPluginFileFilters()) {
+            if (std::regex r(pattern); std::regex_search(file, r)) {
+                if (auto *plugin = loader->loadPlugin(file); plugin) {
+                    if (initPlugin(*plugin, *loader, fs::path(file).parent_path())) {
+                        result = plugin;
+                    }
+                    break;
+                }
             }
-            break;
         }
     }
     return result;

--- a/src/endstone_core/plugin/plugin_manager.cpp
+++ b/src/endstone_core/plugin/plugin_manager.cpp
@@ -106,9 +106,12 @@ std::vector<Plugin *> EndstonePluginManager::loadPlugins(std::string directory)
     std::vector<Plugin *> loaded_plugins;
 
     // TODO(plugin): handling logic for depend, soft_depend, load_before and provides
-    for (const auto &loader : plugin_loaders_) {
+    size_t current_loader_index = 0;
+    while (current_loader_index < plugin_loaders_.size()) {
+        auto &loader = plugin_loaders_[current_loader_index];
         auto plugins = loader->loadPlugins(directory);
-        for (const auto &plugin : plugins) {
+
+        for (auto *plugin : plugins) {
             if (!plugin) {
                 continue;
             }
@@ -117,6 +120,8 @@ std::vector<Plugin *> EndstonePluginManager::loadPlugins(std::string directory)
                 loaded_plugins.push_back(plugin);
             }
         }
+
+        current_loader_index++;
     }
 
     return loaded_plugins;

--- a/src/endstone_core/plugin/plugin_manager.cpp
+++ b/src/endstone_core/plugin/plugin_manager.cpp
@@ -106,11 +106,8 @@ std::vector<Plugin *> EndstonePluginManager::loadPlugins(std::string directory)
     std::vector<Plugin *> loaded_plugins;
 
     // TODO(plugin): handling logic for depend, soft_depend, load_before and provides
-    size_t current_loader_index = 0;
-    while (current_loader_index < plugin_loaders_.size()) {
-        auto &loader = plugin_loaders_[current_loader_index];
+    for (const auto &loader : plugin_loaders_) {
         auto plugins = loader->loadPlugins(directory);
-
         for (auto *plugin : plugins) {
             if (!plugin) {
                 continue;
@@ -120,8 +117,6 @@ std::vector<Plugin *> EndstonePluginManager::loadPlugins(std::string directory)
                 loaded_plugins.push_back(plugin);
             }
         }
-
-        current_loader_index++;
     }
 
     return loaded_plugins;


### PR DESCRIPTION
This Pr modifies the plugin loading logic.

1. change `EndstonePluginManager::loadPlugins(std::string directory)` to subscript traversal (for loop changed to while to avoid iterator failure)

2. fix #98