### PR TITLE
fix: fix find_python when using venv

### DIFF
--- a/python/src/endstone/_internal/plugin_loader.py
+++ b/python/src/endstone/_internal/plugin_loader.py
@@ -32,7 +32,6 @@ def find_python():
         paths.append(os.path.join(sys.prefix, "bin", "python" + f"{sys.version_info.major}.{sys.version_info.minor}"))
         paths.append(os.path.join(sys.prefix, "bin", "python" + f"{sys.version_info.major}"))
         paths.append(os.path.join(sys.prefix, "bin", "python"))
-    paths.append(sys.executable)
 
     for path in paths:
         if os.path.isfile(path):
@@ -50,7 +49,8 @@ class PythonPluginLoader(PluginLoader):
         self._plugins = []
 
         # fix sys.executable variable
-        sys.executable = find_python()
+        if sys.executable is None or sys.executable == "":
+            sys.executable = find_python()
 
         # invalidate previously loaded modules (in case of /reload)
         importlib.invalidate_caches()

--- a/python/src/endstone/_internal/plugin_loader.py
+++ b/python/src/endstone/_internal/plugin_loader.py
@@ -27,11 +27,11 @@ warnings.simplefilter(action="always", category=FutureWarning)
 def find_python():
     paths = []
     if sys.platform == "win32":
-        paths.append(os.path.join(sys.prefix, "python.exe"))
+        paths.append(os.path.join(sys.base_prefix, "python.exe"))
     else:
-        paths.append(os.path.join(sys.prefix, "bin", "python" + f"{sys.version_info.major}.{sys.version_info.minor}"))
-        paths.append(os.path.join(sys.prefix, "bin", "python" + f"{sys.version_info.major}"))
-        paths.append(os.path.join(sys.prefix, "bin", "python"))
+        paths.append(os.path.join(sys.base_prefix, "bin", "python" + f"{sys.version_info.major}.{sys.version_info.minor}"))
+        paths.append(os.path.join(sys.base_prefix, "bin", "python" + f"{sys.version_info.major}"))
+        paths.append(os.path.join(sys.base_prefix, "bin", "python"))
 
     for path in paths:
         if os.path.isfile(path):
@@ -49,8 +49,7 @@ class PythonPluginLoader(PluginLoader):
         self._plugins = []
 
         # fix sys.executable variable
-        if sys.executable is None or sys.executable == "":
-            sys.executable = find_python()
+        sys.executable = find_python()
 
         # invalidate previously loaded modules (in case of /reload)
         importlib.invalidate_caches()

--- a/python/src/endstone/_internal/plugin_loader.py
+++ b/python/src/endstone/_internal/plugin_loader.py
@@ -32,6 +32,7 @@ def find_python():
         paths.append(os.path.join(sys.prefix, "bin", "python" + f"{sys.version_info.major}.{sys.version_info.minor}"))
         paths.append(os.path.join(sys.prefix, "bin", "python" + f"{sys.version_info.major}"))
         paths.append(os.path.join(sys.prefix, "bin", "python"))
+    paths.append(sys.executable)
 
     for path in paths:
         if os.path.isfile(path):


### PR DESCRIPTION
# issue
## reproduce
```powershell
python -m venv .
pip install endstone
endstone
```
## log
```
[2024-12-28 00:44:59.642 ERROR] [Server] Error occurred when trying to register a plugin loader: RuntimeError: Unable to find Python executable. Attempted paths: ['C:\\Users\\killcerr\\endstone\\python.exe']

At:
  C:\Users\killcerr\endstone\Lib\site-packages\endstone\_internal\plugin_loader.py(40): find_python
  C:\Users\killcerr\endstone\Lib\site-packages\endstone\_internal\plugin_loader.py(52): __init__
```
# fix
add ```sys.executable``` to path search list.
# related issue
#28 