### PR TITLE
fix: update description in the document

### DIFF
--- a/docs/tutorials/create-your-first-plugin.md
+++ b/docs/tutorials/create-your-first-plugin.md
@@ -111,7 +111,7 @@ toc_depth: 2
 
     ![New CLion Project](screenshots/clion-create-project.png)
 
-    In the side bar, select **C++ Library**. Select **C++ 17** for **Language standard**. 
+    In the side bar, select **C++ Library**. Select **C++ 20** for **Language standard**. 
     Select **shared** for **Library type**. Click on **Create**. The CLion workspace will pop up and you will see this.
 
     ![CLion Workspace](screenshots/clion-workspace.png)
@@ -137,7 +137,7 @@ toc_depth: 2
     
     project(my_plugin CXX)
     
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     
     include(FetchContent)
@@ -203,7 +203,7 @@ toc_depth: 2
     
     project(my_plugin CXX)
     
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     
     include(FetchContent)


### PR DESCRIPTION
Endstone has required C++20 since [this commit](https://github.com/EndstoneMC/endstone/commit/28b1b20117c2601777f40a0cf59533e63b411151).

Attempting to compile with C++17 will result in an error such as:
```
.../cmake-build-debug/_deps/endstone-src/include/endstone/level/location.h:105:46: error: no member named 'numbers' in namespace 'std'
  105 |         const auto rot_y = getPitch() * std::numbers::pi / 180.0F;
         |                                         ~~~~~^
```