### PR TITLE
Changed VENV_DIR to "$HOME/.virtualenvs/endstone" to avoid polluting users home directory

### DIFF
--- a/scripts/autoinstall.sh
+++ b/scripts/autoinstall.sh
@@ -4,7 +4,7 @@
 
 
 # Define the virtual environment directory
-VENV_DIR="$HOME/venv"
+VENV_DIR="$HOME/.virtualenvs/endstone"
 
 # ASCII Art
 echo -e "\e[0;33m"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,7 +3,7 @@
 # @legitbox here! this file enters the virtual environment and starts endstone, if the software crashes or stops, it autorestarts itself
 
 # Define the virtual environment directory
-VENV_DIR="$HOME/venv"
+VENV_DIR="$HOME/.virtualenvs/endstone"
 
 # ASCII Art
 echo -e "\e[0;33m"


### PR DESCRIPTION
The previous value, `$HOME/venv` is not a good practice for following reasons:
- **Pollutes user's home directory:** `$HOME` is meant for user-level files and config, not for environment-specific files which can be large and messy.
- **Name is too generic:** This directory may or may not be used by other application, or maybe even by the user which can be messy and lead to problems.

The new name, `$HOME/.virtualenvs/endstone` places endstone's virtual environment in it's own separate place following the convention used by [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/).