### PR TITLE
fix(plugin-manager): reverse destruction order of loaders to fix access

### DIFF
--- a/src/endstone/core/plugin/plugin_manager.cpp
+++ b/src/endstone/core/plugin/plugin_manager.cpp
@@ -66,6 +66,11 @@ EndstonePluginManager::EndstonePluginManager(Server &server) : server_(server)
     default_perms_[PermissionLevel::Operator] = {};
     default_perms_[PermissionLevel::Console] = {};
 }
+EndstonePluginManager::~EndstonePluginManager() {
+    while (!plugin_loaders_.empty()) {
+        plugin_loaders_.pop_back();
+    }
+}
 
 void EndstonePluginManager::registerLoader(std::unique_ptr<PluginLoader> loader)
 {
@@ -474,8 +479,8 @@ void EndstonePluginManager::disablePlugin(Plugin &plugin)
 
 void EndstonePluginManager::disablePlugins()
 {
-    for (const auto &plugin : plugins_) {
-        disablePlugin(*plugin);
+    for (auto it = plugins_.rbegin(); it != plugins_.rend(); ++it) {
+        disablePlugin(**it);
     }
 }
 
@@ -486,7 +491,11 @@ void EndstonePluginManager::clearPlugins()
     lookup_names_.clear();
     // TODO: recreate dependency graph
     event_handlers_.clear();
-    plugin_loaders_.clear();
+
+    while (!plugin_loaders_.empty()) {
+        plugin_loaders_.pop_back();
+    }
+
     permissions_.clear();
     default_perms_[PermissionLevel::Default].clear();
     default_perms_[PermissionLevel::Operator].clear();

--- a/src/endstone/core/plugin/plugin_manager.h
+++ b/src/endstone/core/plugin/plugin_manager.h
@@ -36,6 +36,7 @@ namespace endstone::core {
 class EndstonePluginManager : public PluginManager {
 public:
     explicit EndstonePluginManager(Server &server);
+    ~EndstonePluginManager() override;
 
     /** Plugin loading */
     void registerLoader(std::unique_ptr<PluginLoader> loader) override;


### PR DESCRIPTION
This PR fixes the illegal memory access crash that occurs during server shutdown when third-party plugins register custom PluginLoaders.

### 1. Root Cause
When Endstone starts, it first registers built-in loaders to `plugin_loaders_` (a `std::vector` container) in `EndstonePluginManager`:
- `CppPluginLoader` → Index 0
- `PythonPluginLoader` → Index 1

When a third-party Native plugin (loaded by `CppPluginLoader`) registers a custom Loader (e.g., JS/Lua loader), the Loader is `push_back` to the end of the container:
- `XXXPluginLoader` → Index 2

**Core Issues**:
1. `std::vector` destructs elements in forward order by default (from `begin()` to `end()`), so it first destructs `CppPluginLoader` at index 0;
2. During the destruction of `CppPluginLoader`, it cleans up the plugins it manages and calls `FreeLibrary/dlclose` to unload the dynamic library of the third-party plugin;
3. When it comes to destruct `XXXPluginLoader` at index 2, the memory where its virtual destructor `~PluginLoader()` resides has already been released, causing the vtable to jump to an invalid address and triggering an `EXCEPTION_ACCESS_VIOLATION` crash;

### 2. Fix Solution
To address the container destruction order issue, we enforce a reverse cleanup logic following the "Last-In-First-Out (LIFO)" principle:
1. Add a destructor for `EndstonePluginManager` to destruct `plugin_loaders_` in reverse order via `pop_back()`, ensuring custom Loaders are destructed first and built-in Loaders are destructed later;
2. Modify `disablePlugins()` to use reverse iterator traversal, aligning the plugin disabling order with the loading order to avoid dependency invalidation;
3. Replace `plugin_loaders_.clear()` with a `pop_back()` loop to provide double protection against forward destruction.