### PR TITLE
docs: add `--livereload` flag in `Getting Started > Contributing > Documentation`

### DIFF
--- a/docs/getting-started/contributing.md
+++ b/docs/getting-started/contributing.md
@@ -113,7 +113,7 @@ After that, you can either:
 - [Start a live server to preview the documentation as you write](https://squidfunk.github.io/mkdocs-material/creating-your-site/#previewing-as-you-write), or
 
 ```shell
-mkdocs serve
+mkdocs serve --livereload
 ```
 
 - [Build the documentation](https://squidfunk.github.io/mkdocs-material/creating-your-site/#building-your-site)


### PR DESCRIPTION
I was wondering why using the `mkdocs serve` command wasn't actually updating the site live.

The command instead needs to be run as
```bash
mkdocs serve --livereload
```

It turns out this is a bigger issue:
- https://github.com/squidfunk/mkdocs-material/issues/8478
- https://github.com/mkdocs/mkdocs/issues/4081

I considered adding an explanation regarding the workaround in the documentation, but I don't think it's that big of an issue to leave it unmentioned. It's only adding a flag, and you'd figure out that not using the flag means the live preview stops working.

I believe it's a better idea to just not mention it, and anyone curious can have a look at this PR. Otherwise, don't inadvertently lead them down a rabbit hole.