### PR TITLE
Update virtual environment name in documentation from `venv` to `.venv`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ stubs/*
 dist/*
 endstone/_version.py
 conan_provider.cmake
+
+# Python virtual environment
+.venv/**
+.venv

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,10 +25,16 @@ just delete and recreate the environment. It's trivial to set up:
 
 -   Activate the environment with:
 
-    === ":fontawesome-brands-windows: Windows"
+    === ":fontawesome-brands-windows: Command Prompt"
 
-        ``` sh
-        . .venv/Scripts/activate
+        ``` cmd
+        . .venv\Scripts\activate.bat
+        ```
+
+    === ":fontawesome-brands-windows: PowerShell"
+
+        ``` powershell
+        . .venv\Scripts\Activate.ps1
         ```
 
     === ":fontawesome-brands-linux: Linux"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,7 +20,7 @@ just delete and recreate the environment. It's trivial to set up:
 -   Create a new virtual environment with:
 
     ```
-    python3 -m venv venv
+    python3 -m venv .venv
     ```
 
 -   Activate the environment with:
@@ -28,17 +28,17 @@ just delete and recreate the environment. It's trivial to set up:
     === ":fontawesome-brands-windows: Windows"
 
         ``` sh
-        . venv/Scripts/activate
+        . .venv/Scripts/activate
         ```
 
     === ":fontawesome-brands-linux: Linux"
 
         ``` sh
-        . venv/bin/activate
+        . .venv/bin/activate
         ```
 
 
-    Your terminal should now print `(venv)` before the prompt, which is how you
+    Your terminal should now print `(.venv)` before the prompt, which is how you
     know that you are inside the virtual environment that you just created.
 
 -   Exit the environment with:

--- a/docs/tutorials/install-your-plugin.md
+++ b/docs/tutorials/install-your-plugin.md
@@ -92,4 +92,4 @@ Before installing your first plugin, you will need to build it.
 
 [editable installation]: https://pip.pypa.io/en/latest/topics/local-project-installs/
 
-[virtual environment]: ../../getting-started/installation/#environment
+[virtual environment]: ../getting-started/installation.md#environment

--- a/docs/tutorials/install-your-plugin.md
+++ b/docs/tutorials/install-your-plugin.md
@@ -39,22 +39,28 @@ Before installing your first plugin, you will need to build it.
 
     To do so, you will need the activate the [virtual environment]. Please make sure Endstone is also installed inside the environment.
 
-    === ":fontawesome-brands-windows: Windows"
+    === ":fontawesome-brands-windows: Command Prompt"
 
-        ``` sh
-        . venv/Scripts/activate
+        ``` cmd
+        . .venv\Scripts\activate.bat
+        ```
+
+    === ":fontawesome-brands-windows: PowerShell"
+
+        ``` powershell
+        . .venv\Scripts\Activate.ps1
         ```
 
     === ":fontawesome-brands-linux: Linux"
 
         ``` sh
-        . venv/bin/activate
+        . .venv/bin/activate
         ```
     
     You can now enter this “development mode” by performing an [editable installation] inside the virtual environment, 
     using pip’s `-e/--editable` flag, as shown below:
 
-    ``` sh title="(venv)"
+    ``` sh title="(.venv)"
     pip install --editable .
     ```
 


### PR DESCRIPTION
**Note that this updates `.gitignore` in addition to documentation pages.**

This PR changes a few things regarding the documentation for installation:
- updates the virtual environment's name to `.venv` from `venv` to align it with [`uv`'s functionality](https://docs.astral.sh/uv/pip/compatibility/#virtual-environments-by-default).
- separate the `Windows` tab into `Command Prompt` and `PowerShell` (see [here](https://docs.python.org/3/library/venv.html#how-venvs-work) for the command syntax used)
- update the `.gitignore` file to exclude the virtual environment

This is what the updated version looks like:

<img width="780" height="614" alt="New version" src="https://github.com/user-attachments/assets/e4422c49-eb21-4995-8e19-839692cd9820" />

---

This is what the old version looks like:

<img width="780" height="614" alt="image" src="https://github.com/user-attachments/assets/b820077f-ef50-4aab-9773-6536f9b98f61" />
