### PR TITLE
docs: exclude `web-flow` author from showing up as a committer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,8 @@ plugins:
       enabled: !ENV [ CI, false ]
       repository: EndstoneMC/endstone
       branch: main
+      exclude_committers:
+        - web-flow
   - macros
   - mkdocstrings:
       enabled: !ENV [ CI, false ]


### PR DESCRIPTION
This PR stops @web-flow from appearing as a contributor in the documentation - it's not actually a contributor - it shows up when edits are made on the GitHub website, as opposed to making them locally.

<img width="513" height="103" alt="Removal of web flow" src="https://github.com/user-attachments/assets/803bf527-dc45-4f02-8733-7e01acc16a91" />
