### PR TITLE
docs: enhance faq

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -10,7 +10,6 @@ comments: true
 
     Accordingly, Endstone only supports Windows and Ubuntu Linux. Other platforms may or may not function.
 
-    BDS natively supports the `x86-64` CPU architecture. Systems with `arm` CPU architectures are not officially supported.
+    BDS natively supports the `x86-64` CPU architecture. Systems with `arm` CPU architectures are not officially supported.[^1]
 
-!!! tip "ARM Architecture (Apple Silicon, etc.)"
-    While BDS is natively built for `x86-64`, it can run exceptionally well on `arm` systems using Docker emulation. In our testing on an **Apple M1 running macOS Tahoe (26.3.1)**, performance remains stable with little-to-no latency impact!
+[^1]: While BDS is natively built for `x86-64`, it can run exceptionally well on `arm` systems using Docker emulation. In our testing on an **Apple M1 running macOS Tahoe (26.3.1)**, performance remains stable with little-to-no latency impact!

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -14,4 +14,4 @@ comments: true
 
 [^1]: While BDS is natively built for `x86-64`, it can run exceptionally well on `arm` systems using [Docker emulation]. In our testing on an **Apple M1 running macOS Tahoe (26.3.1)**, performance remains stable with little-to-no latency impact! 
 
-[Docker emulation]: installation#with-docker
+[Docker emulation]: installation.md/#with-docker-latest-arm-with-emulation

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -8,6 +8,6 @@ comments: true
 
     Endstone is built around the official [Bedrock Dedicated Server (BDS)](https://www.minecraft.net/download/server/bedrock), which supports Windows and Ubuntu Linux.
 
-    Accordingly, Endstone only supports Windows and Ubuntu Linux. Other platforms may or may function.
+    Accordingly, Endstone only supports Windows and Ubuntu Linux. Other platforms may or may not function.
 
     BDS only supports the `x86-64` CPU architecture. Systems with `arm` CPU architectures are not supported.

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -10,4 +10,7 @@ comments: true
 
     Accordingly, Endstone only supports Windows and Ubuntu Linux. Other platforms may or may not function.
 
-    BDS only supports the `x86-64` CPU architecture. Systems with `arm` CPU architectures are not supported.
+    BDS natively supports the `x86-64` CPU architecture. Systems with `arm` CPU architectures are not officially supported.
+
+!!! tip "ARM Architecture (Apple Silicon, etc.)"
+    While BDS is natively built for `x86-64`, it can run exceptionally well on `arm` systems using Docker emulation. In our testing on an **Apple M1 running macOS Tahoe (26.3.1)**, performance remains stable with little-to-no latency impact!

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -12,4 +12,6 @@ comments: true
 
     BDS natively supports the `x86-64` CPU architecture. Systems with `arm` CPU architectures are not officially supported.[^1]
 
-[^1]: While BDS is natively built for `x86-64`, it can run exceptionally well on `arm` systems using Docker emulation. In our testing on an **Apple M1 running macOS Tahoe (26.3.1)**, performance remains stable with little-to-no latency impact!
+[^1]: While BDS is natively built for `x86-64`, it can run exceptionally well on `arm` systems using [Docker emulation]. In our testing on an **Apple M1 running macOS Tahoe (26.3.1)**, performance remains stable with little-to-no latency impact! 
+
+[Docker emulation]: installation#with-docker

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -12,6 +12,6 @@ comments: true
 
     BDS natively supports the `x86-64` CPU architecture. Systems with `arm` CPU architectures are not officially supported.[^1]
 
-[^1]: While BDS is natively built for `x86-64`, it can run exceptionally well on `arm` systems using [Docker emulation]. In our testing on an **Apple M1 running macOS Tahoe (26.3.1)**, performance remains stable with little-to-no latency impact! 
+[^1]: While BDS is natively built for `x86-64`, it can also run well on `arm` systems via [Docker emulation]. Using emulation can also allow Endstone to run on macOS.
 
 [Docker emulation]: installation.md/#with-docker-latest-arm-with-emulation

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,25 +69,19 @@ from the last step. Open up a terminal and install Endstone with:
 The official [Docker image] is a great way to get the Endstone server up and running in a few
 minutes, and enables you to run Endstone on ARM through emulation. Open up a terminal and pull the image with:
 
-=== "Latest (x86/x64, Native)"
+=== "Latest"
 
     ```shell
     docker pull endstone/endstone
     ```
 
-=== "Latest (ARM, with Emulation)"
+=== "Latest / :fontawesome-brands-apple: MacOS / :fontawesome-solid-microchip: with Emulation"
 
     ```shell
     docker pull --platform linux/amd64 endstone/endstone
     ```
 
-    Then, you can run a new server like this:
-
-    ```shell
-    # Create a new server called "endstone-server" that emulates an `amd64` architecture CPU, and bind the host port
-    # `19132` to the same port in the container.
-    docker run --platform linux/amd64 -p 19132:19132 -d --name endstone-server endstone/endstone
-    ```
+    Note that if you are on an `x86_64` machine and you are not on MacOS/Windows, emulation will not apply.
 
 If you're new to Docker, check out the [Docker beginner's guide].
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -67,16 +67,34 @@ from the last step. Open up a terminal and install Endstone with:
 ### with docker
 
 The official [Docker image] is a great way to get the Endstone server up and running in a few
-minutes. Open up a terminal and pull the image with:
+minutes, and enables you to run Endstone on ARM through emulation. Open up a terminal and pull the image with:
 
-=== "Latest"
+=== "Latest (x86/x64, Native)"
 
-    ```
+    ```shell
     docker pull endstone/endstone
     ```
+
+=== "Latest (ARM, with Emulation)"
+
+    ```shell
+    docker pull --platform linux/amd64 endstone/endstone
+    ```
+
+    Then, you can run a new server like this:
+
+    ```shell
+    # Create a new server called "endstone-server" that emulates an `amd64` architecture CPU, and bind the host port
+    # `19132` to the same port in the container.
+    docker run --platform linux/amd64 -p 19132:19132 -d --name endstone-server endstone/endstone
+    ```
+
+If you're new to Docker, check out the [Docker beginner's guide].
 
 [Python package]: https://pypi.org/project/endstone/
 
 [virtual environment]: https://realpython.com/what-is-pip/#using-pip-in-a-python-virtual-environment
 
 [Docker image]: https://hub.docker.com/r/endstone/endstone/
+
+[Docker beginner's guide]: https://docs.docker.com/get-started/

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -75,7 +75,7 @@ minutes, and enables you to run Endstone on ARM through emulation. Open up a ter
     docker pull endstone/endstone
     ```
 
-=== "Latest / :fontawesome-brands-apple: MacOS / :fontawesome-solid-microchip: with Emulation"
+=== "Latest / :fontawesome-brands-apple: macOS / :fontawesome-solid-microchip: with emulation"
 
     ```shell
     docker pull --platform linux/amd64 endstone/endstone

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -81,7 +81,7 @@ minutes, and enables you to run Endstone on ARM through emulation. Open up a ter
     docker pull --platform linux/amd64 endstone/endstone
     ```
 
-    Note that if you are on an `x86_64` machine and you are not on MacOS/Windows, emulation will not apply.
+    Note that if you are on an `x86-64` machine and you are not on macOS or Windows, emulation will not apply.
 
 If you're new to Docker, check out the [Docker beginner's guide].
 

--- a/docs/getting-started/start-your-server.md
+++ b/docs/getting-started/start-your-server.md
@@ -25,6 +25,20 @@ Alternatively, if you're running Endstone from within Docker, use:
     docker run --rm -it -v "%cd%":/home/endstone -p 19132:19132/udp endstone/endstone
     ```
 
+=== ":fontawesome-brands-linux: Linux / :fontawesome-brands-apple: MacOS / :fontawesome-solid-microchip: with emulation"
+
+    ```
+    docker run \
+    --platform linux/amd64 \
+    -p 19132:19132 \
+    -it \
+    -v ${PWD}:/home/endstone \
+    --name endstone-server \
+    endstone/endstone
+    ```
+
+    Note that if you are on an `x86_64` machine and you are not on MacOS/Windows, emulation will not apply.
+
 You should see this in your console:
 
 ![Start your server](start-your-server.png)

--- a/docs/getting-started/start-your-server.md
+++ b/docs/getting-started/start-your-server.md
@@ -25,7 +25,7 @@ Alternatively, if you're running Endstone from within Docker, use:
     docker run --rm -it -v "%cd%":/home/endstone -p 19132:19132/udp endstone/endstone
     ```
 
-=== ":fontawesome-brands-linux: Linux / :fontawesome-brands-apple: MacOS / :fontawesome-solid-microchip: with emulation"
+=== ":fontawesome-brands-linux: Linux / :fontawesome-brands-apple: macOS / :fontawesome-solid-microchip: with emulation"
 
     ```
     docker run \

--- a/docs/getting-started/start-your-server.md
+++ b/docs/getting-started/start-your-server.md
@@ -37,7 +37,7 @@ Alternatively, if you're running Endstone from within Docker, use:
     endstone/endstone
     ```
 
-    Note that if you are on an `x86_64` machine and you are not on MacOS/Windows, emulation will not apply.
+    Note that if you are on an `x86-64` machine and you are not on macOS or Windows, emulation will not apply.
 
 You should see this in your console:
 


### PR DESCRIPTION
Fix a grammatical error and acknowledge the viability with Endstone and ARM architectures.

I've added a tip in the FAQ that emphasizes how Docker emulation can make Endstone work on ARM with good performance. As the popularity of ARM for servers rises, I think making Endstone sound more viable for ARM in places such as the FAQ is important for the project's growth.