### PR TITLE
fix(network): guard closeConnection against double onConnectionClosed dispatch

### DIFF
--- a/src/bedrock/network/network_connection.h
+++ b/src/bedrock/network/network_connection.h
@@ -60,6 +60,7 @@ protected:
     std::array<std::vector<PausedPacket>, 2UL> paused_packets_;
 
 private:
+    friend class NetworkSystem;
     bool disconnected_;
     bool should_close_connection_;  // +377
     bool encryption_disabled_;

--- a/src/bedrock/network/network_system.cpp
+++ b/src/bedrock/network/network_system.cpp
@@ -14,6 +14,8 @@
 
 #include "bedrock/network/network_system.h"
 
+#include <chrono>
+
 Bedrock::NotNullNonOwnerPtr<RemoteConnector> NetworkSystem::getRemoteConnector()
 {
     return remote_connector_.get();
@@ -45,6 +47,14 @@ NetworkConnection *NetworkSystem::_getConnectionFromId(const NetworkIdentifier &
         }
     }
     return nullptr;
+}
+
+void NetworkSystem::setCloseConnection(const NetworkIdentifier &id)
+{
+    if (auto *connection = _getConnectionFromId(id)) {
+        connection->should_close_connection_ = true;
+        connection->closed_time = std::chrono::steady_clock::now();
+    }
 }
 
 void NetworkSystem::_sendInternal(const NetworkIdentifier &id, const Packet &packet, const std::string &data)

--- a/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
+++ b/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
@@ -57,18 +57,8 @@ void ServerNetworkHandler::disconnectClientWithMessage(const NetworkIdentifier &
     // #blameMojang - BDS politely asks clients to disconnect and waits for acknowledgment.
     // Malicious clients can simply ignore this and keep spamming packets indefinitely.
     // Fix: don't ask, just close the connection.
-    //
-    // Guard: only force-close if the connection still exists AND is not already marked for closure.
-    // For a natural disconnect (player closes game), the BDS network layer sets should_close_connection_=true
-    // and fires onConnectionClosed *before* reaching disconnectClientWithMessage. Calling closeConnection
-    // again would trigger a second onConnectionClosed dispatch on already-freed BDS/Script API objects,
-    // causing EXCEPTION_ACCESS_VIOLATION — especially after /reload reinitialises the script runtime.
     if (sub_id == SubClientId::PrimaryClient) {
-        auto &network = server.getServer().getNetwork();
-        const auto *connection = network._getConnectionFromId(id);
-        if (connection != nullptr && !connection->shouldCloseConnection()) {
-            network.closeConnection(id, reason, message);
-        }
+        server.getServer().getNetwork().setCloseConnection(id);
     }
 }
 

--- a/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
+++ b/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
@@ -57,8 +57,18 @@ void ServerNetworkHandler::disconnectClientWithMessage(const NetworkIdentifier &
     // #blameMojang - BDS politely asks clients to disconnect and waits for acknowledgment.
     // Malicious clients can simply ignore this and keep spamming packets indefinitely.
     // Fix: don't ask, just close the connection.
+    //
+    // Guard: only force-close if the connection still exists AND is not already marked for closure.
+    // For a natural disconnect (player closes game), the BDS network layer sets should_close_connection_=true
+    // and fires onConnectionClosed *before* reaching disconnectClientWithMessage. Calling closeConnection
+    // again would trigger a second onConnectionClosed dispatch on already-freed BDS/Script API objects,
+    // causing EXCEPTION_ACCESS_VIOLATION — especially after /reload reinitialises the script runtime.
     if (sub_id == SubClientId::PrimaryClient) {
-        server.getServer().getNetwork().closeConnection(id, reason, message);
+        auto &network = server.getServer().getNetwork();
+        const auto *connection = network._getConnectionFromId(id);
+        if (connection != nullptr && !connection->shouldCloseConnection()) {
+            network.closeConnection(id, reason, message);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

When a player disconnects naturally (client closes game), the server crashes with EXCEPTION_ACCESS_VIOLATION (0xc0000005). The crash is intermittent under normal conditions but becomes ~50% reproducible after running /reload.

**Crash stack (simplified):**
`
#24  ServerNetworkHandler::disconnectClientWithMessage  at server_network_handler.cpp:61
#23  NetworkSystem::closeConnection                     at network_system.cpp:31
#9–22  <BDS internals — crash here>
`

## Root Cause

The existing hook in disconnectClientWithMessage unconditionally calls NetworkSystem::closeConnection after ENDSTONE_HOOK_CALL_ORIGINAL. This causes a **double onConnectionClosed dispatch**:

1. For a **natural disconnect**, the BDS network layer (RakNet/NetherNet) already sets should_close_connection_ = true and fires onConnectionClosed *before* the call chain ever reaches disconnectClientWithMessage.
2. Endstone's hook then calls closeConnection again, which fires onConnectionClosed a second time on data already freed during the first call — a classic use-after-free.

**Why is the crash linked to /reload?**

EndstoneServer::reload() → eloadData() → onRequestResourceReload() reinitialises the Bedrock Script API runtime. After reinitialisation, BDS re-registers its internal onConnectionClosed listeners against freshly-allocated Script API objects. The first dispatch frees those objects; the second dispatch accesses freed memory and crashes. Before a reload the timing is more forgiving, so crashes are rare.

## Fix

Before calling closeConnection, verify two conditions:
1. The NetworkConnection still exists in the connections_ list — _getConnectionFromId(id) != nullptr.
2. The connection is **not** already marked for closure — !connection->shouldCloseConnection().

This preserves the intended anti-malicious-client behaviour (server-initiated kicks/bans have a live connection with the flag clear, so closeConnection still fires), while skipping the redundant call for naturally-disconnected players.

## Testing

- Player disconnects naturally → no crash, no double onConnectionClosed
- /reload followed by player leaving → no crash  
- Player kicked via player.kick() / IP-ban / ban → connection force-closed as expected (malicious-client protection intact)