### PR TITLE
fix: Add isPlayerInitialized check before firing PlayerDropItemEvent

### DIFF
--- a/src/endstone/runtime/bedrock_hooks/player.cpp
+++ b/src/endstone/runtime/bedrock_hooks/player.cpp
@@ -81,7 +81,7 @@ bool Player::drop(const ItemStack &item, bool randomly)
 {
     const auto &server = entt::locator<endstone::core::EndstoneServer>::value();
     auto &player = getEndstoneActor<endstone::core::EndstonePlayer>();
-    if (isAlive()) {
+    if (isAlive() && isPlayerInitialized()) {
         const auto drop = endstone::core::EndstoneItemStack::fromMinecraft(item);
         endstone::PlayerDropItemEvent e(player, drop);
         server.getPluginManager().callEvent(e);


### PR DESCRIPTION
# Problem
When player fills whole inventory with items, and then takes another one (which doesn't stack with those that are in player inventory) in cursor slot, crafting table slot or etc., and then disconnects, upon reconnecting endstone::onPlayerDropItem fires. But because item doesn't actually drop, it leads to uninitialized data about the event, for example in which dimension the item was dropped, and if there is a plugin that listens to that event and tries to do something with that data, it leads to crash.

# Fix
Add Player::isPlayerInitialized check before firing endstone::PlayerDropItemEvent

# Crashlog
Here is what happens (before fix):
[crash-2026-05-23-18.25.50-server.txt](https://github.com/user-attachments/files/28181264/crash-2026-05-23-18.25.50-server.txt)
