### PR TITLE
Add "setuptools-scm" to `build-system.requires`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["conan-py-build", "cmake", "ninja"]
+requires = ["conan-py-build", "cmake", "ninja", "setuptools-scm"]
 build-backend = "conan_py_build.build"
 
 [project]


### PR DESCRIPTION
Without this fix, `uv sync` fails with error "ModuleNotFoundError: No module named setuptools_scm".