### PR TITLE
fix(scheduler): improve async task lifetime safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `/reload` now waits up to 2.5 seconds for running async tasks to finish, then logs a warning naming the plugin ("Nag author(s) ...") and proceeds, matching CraftBukkit. Previously the reload tore plugins down immediately, so a still-running async task could crash the server.
+
 ### Fixed
 
+- Fixed `Scheduler.is_running()` returning the opposite of the truth for async tasks: `True` while the task was idle and `False` while it was actually executing.
+- Fixed a class of scheduler crashes and leaks around async tasks: a task submitted to the thread pool could be destroyed while still queued, a task cancelled at the wrong moment could still run, and tasks scheduled from another thread or from inside a task callback could leak or fire one tick early (#436).
+- Fixed cancelled tasks holding on to their callbacks until their scheduled tick; they are now released on the next tick, and before plugin libraries are unloaded on `/reload`.
 - Fixed `PluginLoader.disable_plugin` in Python enabling the plugin instead of disabling it.
 - Fixed an access-violation crash when converting NBT data containing an empty byte array to a string, for example the item NBT of a firework star (#443).
 - Fixed death messages for entity and projectile kills always showing the generic "Player died" instead of the detailed vanilla message, such as "Player was slain by Zombie". Death message overrides set on the damage source are now honored as well (#438).

--- a/src/endstone/core/plugin/plugin_manager.cpp
+++ b/src/endstone/core/plugin/plugin_manager.cpp
@@ -28,7 +28,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include "endstone/core/logger_factory.h"
-#include "endstone/core/scheduler/scheduler.h"
 #include "endstone/event/event.h"
 #include "endstone/event/event_handler.h"
 #include "endstone/event/handler_list.h"
@@ -493,11 +492,6 @@ void EndstonePluginManager::disablePlugins()
 void EndstonePluginManager::clearPlugins()
 {
     disablePlugins();
-    if (auto *scheduler = dynamic_cast<EndstoneScheduler *>(&server_.getScheduler())) {
-        for (auto *plugin : plugins_) {
-            scheduler->waitForAsyncTasks(*plugin);
-        }
-    }
     plugins_.clear();
     lookup_names_.clear();
     // TODO: recreate dependency graph

--- a/src/endstone/core/plugin/plugin_manager.cpp
+++ b/src/endstone/core/plugin/plugin_manager.cpp
@@ -28,6 +28,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include "endstone/core/logger_factory.h"
+#include "endstone/core/scheduler/scheduler.h"
 #include "endstone/event/event.h"
 #include "endstone/event/event_handler.h"
 #include "endstone/event/handler_list.h"
@@ -492,6 +493,11 @@ void EndstonePluginManager::disablePlugins()
 void EndstonePluginManager::clearPlugins()
 {
     disablePlugins();
+    if (auto *scheduler = dynamic_cast<EndstoneScheduler *>(&server_.getScheduler())) {
+        for (auto *plugin : plugins_) {
+            scheduler->waitForAsyncTasks(*plugin);
+        }
+    }
     plugins_.clear();
     lookup_names_.clear();
     // TODO: recreate dependency graph

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -74,6 +74,7 @@ void EndstoneAsyncTask::run()
         // task is done (one-shot) or has been cancelled while still running.
         finished = workers_.empty() && (getPeriod() == 0 || isCancelled());
     }
+    condition_.notify_all();
 
     // Remove ourselves outside the lock: removeTask() takes the scheduler's tasks_mtx_, which must
     // never be held together with our own mutex_ (the cancel path takes them in the opposite order).
@@ -103,6 +104,12 @@ std::vector<EndstoneAsyncTask::Worker> EndstoneAsyncTask::getWorkers() const
 {
     std::lock_guard lock{mutex_};
     return workers_;
+}
+
+void EndstoneAsyncTask::wait()
+{
+    std::unique_lock lock{mutex_};
+    condition_.wait(lock, [this]() { return workers_.empty(); });
 }
 
 }  // namespace endstone::core

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -46,6 +46,8 @@ void EndstoneAsyncTask::run()
         getOwner()->getLogger().warning("Plugin {} generated an exception while executing task {}: {}",
                                         getOwner()->getName(), getTaskId(), e.what());
     }
+    catch (...) {
+    }
 
     bool finished = false;
     {

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -47,6 +47,7 @@ void EndstoneAsyncTask::run()
                                         getOwner()->getName(), getTaskId(), e.what());
     }
     catch (...) {
+        getScheduler().getLogger().warning("Plugin task {} generated an unknown exception", getTaskId());
     }
 
     bool finished = false;

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -28,13 +28,12 @@ bool EndstoneAsyncTask::isSync() const
 
 void EndstoneAsyncTask::run()
 {
-    if (isCancelled()) {
-        return;
-    }
-
     auto thread_id = std::this_thread::get_id();
     {
         std::lock_guard lock{mutex_};
+        if (isCancelled()) {
+            return;
+        }
         workers_.push_back({thread_id, getTaskId(), getOwner()});
     }
 
@@ -85,11 +84,11 @@ void EndstoneAsyncTask::run()
 
 void EndstoneAsyncTask::doCancel()
 {
-    // Set cancelled flag to true to not accept new runs
-    EndstoneTask::doCancel();
     bool idle;
     {
         std::lock_guard lock{mutex_};
+        // Set cancelled flag to true to not accept new runs
+        EndstoneTask::doCancel();
         // Do not remove the task unless we are idle; a running worker will remove it when it finishes.
         idle = workers_.empty();
     }

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -84,11 +84,10 @@ void EndstoneAsyncTask::run()
 
 void EndstoneAsyncTask::doCancel()
 {
+    EndstoneTask::doCancel();
     bool idle;
     {
         std::lock_guard lock{mutex_};
-        // Set cancelled flag to true to not accept new runs
-        EndstoneTask::doCancel();
         // Do not remove the task unless we are idle; a running worker will remove it when it finishes.
         idle = workers_.empty();
     }

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -46,9 +46,6 @@ void EndstoneAsyncTask::run()
         getOwner()->getLogger().warning("Plugin {} generated an exception while executing task {}: {}",
                                         getOwner()->getName(), getTaskId(), e.what());
     }
-    catch (...) {
-        getScheduler().getLogger().warning("Plugin task {} generated an unknown exception", getTaskId());
-    }
 
     bool finished = false;
     {
@@ -77,7 +74,6 @@ void EndstoneAsyncTask::run()
         // task is done (one-shot) or has been cancelled while still running.
         finished = workers_.empty() && (getPeriod() == 0 || isCancelled());
     }
-    condition_.notify_all();
 
     // Remove ourselves outside the lock: removeTask() takes the scheduler's tasks_mtx_, which must
     // never be held together with our own mutex_ (the cancel path takes them in the opposite order).
@@ -107,12 +103,6 @@ std::vector<EndstoneAsyncTask::Worker> EndstoneAsyncTask::getWorkers() const
 {
     std::lock_guard lock{mutex_};
     return workers_;
-}
-
-void EndstoneAsyncTask::wait()
-{
-    std::unique_lock lock{mutex_};
-    condition_.wait(lock, [this]() { return workers_.empty(); });
 }
 
 }  // namespace endstone::core

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -98,7 +98,7 @@ void EndstoneAsyncTask::doCancel()
     }
 }
 
-std::vector<EndstoneAsyncTask::Worker> EndstoneAsyncTask::getWorkers() const
+std::vector<EndstoneWorker> EndstoneAsyncTask::getWorkers() const
 {
     std::lock_guard lock{mutex_};
     return workers_;

--- a/src/endstone/core/scheduler/async_task.cpp
+++ b/src/endstone/core/scheduler/async_task.cpp
@@ -37,12 +37,12 @@ void EndstoneAsyncTask::run()
         workers_.push_back({thread_id, getTaskId(), getOwner()});
     }
 
-    std::optional<std::exception> exception;
+    std::optional<std::string> exception;
     try {
         EndstoneTask::run();
     }
     catch (std::exception &e) {
-        exception = e;
+        exception = e.what();
         getOwner()->getLogger().warning("Plugin {} generated an exception while executing task {}: {}",
                                         getOwner()->getName(), getTaskId(), e.what());
     }
@@ -66,7 +66,7 @@ void EndstoneAsyncTask::run()
             getOwner()->getLogger().error(std::format("Unable to remove worker {} on task {} for {}", tid.str(),
                                                       getTaskId(), getOwner()->getDescription().getFullName()));
             if (exception.has_value()) {
-                getOwner()->getLogger().error(exception->what());
+                getOwner()->getLogger().error(*exception);
             }
         }
 

--- a/src/endstone/core/scheduler/async_task.h
+++ b/src/endstone/core/scheduler/async_task.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <condition_variable>
 #include <mutex>
 #include <thread>
 
@@ -36,9 +37,11 @@ public:
     void doCancel() override;
 
     std::vector<Worker> getWorkers() const;
+    void wait();
 
 private:
     mutable std::mutex mutex_;
+    std::condition_variable condition_;
     std::vector<Worker> workers_;
 };
 

--- a/src/endstone/core/scheduler/async_task.h
+++ b/src/endstone/core/scheduler/async_task.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <condition_variable>
 #include <mutex>
 #include <thread>
 
@@ -37,11 +36,9 @@ public:
     void doCancel() override;
 
     std::vector<Worker> getWorkers() const;
-    void wait();
 
 private:
     mutable std::mutex mutex_;
-    std::condition_variable condition_;
     std::vector<Worker> workers_;
 };
 

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -292,6 +292,23 @@ void EndstoneScheduler::removeTask(TaskId id)
     tasks_.erase(it);
 }
 
+void EndstoneScheduler::waitForAsyncTasks(Plugin &plugin)
+{
+    std::vector<std::shared_ptr<EndstoneAsyncTask>> tasks;
+    {
+        std::lock_guard lock{tasks_mtx_};
+        for (const auto &entry : tasks_) {
+            const auto &task = entry.second;
+            if (!task->isSync() && task->getOwner() == &plugin) {
+                tasks.push_back(std::static_pointer_cast<EndstoneAsyncTask>(task));
+            }
+        }
+    }
+    for (const auto &task : tasks) {
+        task->wait();
+    }
+}
+
 TaskId EndstoneScheduler::nextId()
 {
     TaskId id;

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -167,7 +167,7 @@ bool EndstoneScheduler::isRunning(TaskId id)
     }
     // Query the workers outside the lock: getWorkers() takes the task's own mutex, which must
     // never be held together with tasks_mtx_ (see run()/doCancel()).
-    return std::static_pointer_cast<EndstoneAsyncTask>(task)->getWorkers().empty();
+    return !std::static_pointer_cast<EndstoneAsyncTask>(task)->getWorkers().empty();
 }
 
 bool EndstoneScheduler::isQueued(TaskId id)

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -261,6 +261,10 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
                 catch (std::exception &e) {
                     server_.getLogger().error("Could not execute task with id {}: {}", task->getTaskId(), e.what());
                 }
+                catch (...) {
+                    server_.getLogger().error("Could not execute task with id {}: unknown exception",
+                                              task->getTaskId());
+                }
                 current_task_ = 0;
             }
             else {

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -31,6 +31,11 @@ Result<void> validate(const Plugin &plugin, const std::function<void()> &task)
 
 EndstoneScheduler::EndstoneScheduler(Server &server) : server_(server) {}
 
+Logger &EndstoneScheduler::getLogger() const
+{
+    return server_.getLogger();
+}
+
 std::shared_ptr<Task> EndstoneScheduler::runTask(Plugin &plugin, std::function<void()> task)
 {
     return runTaskLater(plugin, task, 0);
@@ -270,7 +275,19 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
                 current_task_ = 0;
             }
             else {
-                executor_.submit([task]() { task->run(); });
+                try {
+                    executor_.submit([task]() { task->run(); });
+                }
+                catch (std::exception &e) {
+                    task->doCancel();
+                    server_.getLogger().error("Could not submit task with id {}: {}", task->getTaskId(), e.what());
+                    continue;
+                }
+                catch (...) {
+                    task->doCancel();
+                    server_.getLogger().error("Could not submit task with id {}: unknown exception", task->getTaskId());
+                    continue;
+                }
             }
 
             if (task->getPeriod() > 0) {  // repeating task

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -14,6 +14,8 @@
 
 #include "endstone/core/scheduler/scheduler.h"
 
+#include <algorithm>
+
 #include "endstone/core/scheduler/async_task.h"
 
 namespace endstone::core {
@@ -118,6 +120,34 @@ void EndstoneScheduler::cancelTasks(Plugin &plugin)
     // which re-locks tasks_mtx_ and would deadlock if we still held it here.
     for (const auto &task : cancelling) {
         task->doCancel();
+    }
+
+    // Remove scheduler-owned references to cancelled plugin tasks from the
+    // pending and scheduled queues so their callbacks can be released promptly.
+    std::vector<std::shared_ptr<EndstoneTask>> pending;
+    std::shared_ptr<EndstoneTask> task;
+    while (pending_.try_dequeue(task)) {
+        if (task->getOwner() == &plugin) {
+            task.reset();
+        }
+        else {
+            pending.push_back(std::move(task));
+        }
+    }
+    for (auto &pending_task : pending) {
+        pending_.enqueue(std::move(pending_task));
+    }
+
+    for (auto it = queue_.begin(); it != queue_.end();) {
+        auto &tasks = it->second;
+        std::erase_if(tasks, [&plugin](const auto &queued) { return queued->getOwner() == &plugin; });
+        if (tasks.empty()) {
+            it = queue_.erase(it);
+        }
+        else {
+            std::make_heap(tasks.begin(), tasks.end(), cmp_);
+            ++it;
+        }
     }
 }
 

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<Task> EndstoneScheduler::runTaskTimer(Plugin &plugin, std::funct
     }
 
     auto t = std::make_shared<EndstoneTask>(*this, plugin, task, nextId(), period);
-    t->setNextRun(current_tick_ + delay);
+    t->setNextRun(current_tick_.load(std::memory_order_relaxed) + delay);
     addTask(t);
     return t;
 }
@@ -73,7 +73,7 @@ std::shared_ptr<Task> EndstoneScheduler::runTaskTimerAsync(Plugin &plugin, std::
     }
 
     auto t = std::make_shared<EndstoneAsyncTask>(*this, plugin, task, nextId(), period);
-    t->setNextRun(current_tick_ + delay);
+    t->setNextRun(current_tick_.load(std::memory_order_relaxed) + delay);
     addTask(t);
     return t;
 }
@@ -195,16 +195,18 @@ std::shared_ptr<Task> EndstoneScheduler::runTask(std::function<void()> task)
         return nullptr;
     }
     auto t = std::make_shared<EndstoneTask>(*this, task, nextId(), 0);
-    t->setNextRun(current_tick_);
+    t->setNextRun(current_tick_.load(std::memory_order_relaxed));
     addTask(t);
     return t;
 }
 
 void EndstoneScheduler::addTask(std::shared_ptr<EndstoneTask> task)
 {
+    {
+        std::lock_guard lock{tasks_mtx_};
+        tasks_[task->getTaskId()] = task;
+    }
     pending_.enqueue(task);
-    std::lock_guard lock{tasks_mtx_};
-    tasks_[task->getTaskId()] = task;
 }
 
 void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
@@ -221,7 +223,7 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
     // +1 so the first heartbeat is tick 1: the counter advances 0 -> 1 on the first tick, matching
     // the contract that a task registered with delay N runs on the Nth tick.
     current_tick = current_tick - *base_tick_ + 1;
-    current_tick_ = current_tick;
+    current_tick_.store(current_tick, std::memory_order_relaxed);
 
     // Consume the tasks in the pending queue
     std::shared_ptr<EndstoneTask> pending_task;

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -311,6 +311,7 @@ void EndstoneScheduler::waitForAsyncTasks(Plugin &plugin)
     for (const auto &task : tasks) {
         task->wait();
     }
+    executor_.wait();
 }
 
 TaskId EndstoneScheduler::nextId()

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -221,6 +221,7 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
     // +1 so the first heartbeat is tick 1: the counter advances 0 -> 1 on the first tick, matching
     // the contract that a task registered with delay N runs on the Nth tick.
     current_tick = current_tick - *base_tick_ + 1;
+    current_tick_ = current_tick;
 
     // Consume the tasks in the pending queue
     std::shared_ptr<EndstoneTask> pending_task;
@@ -279,7 +280,6 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
 
         it = queue_.erase(it);
     }
-    current_tick_ = current_tick;
 }
 
 void EndstoneScheduler::removeTask(TaskId id)

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -95,7 +95,8 @@ void EndstoneScheduler::cancelTask(TaskId id)
     // Cancel outside the lock: an async task's doCancel() may call back into removeTask(),
     // which re-locks tasks_mtx_ and would deadlock if we still held it here.
     task->doCancel();
-    purge_requested_.store(true, std::memory_order_release);
+    // CraftScheduler#cancelTask queues a -1 task to purge queue_; we ask the main thread with a flag.
+    needs_purge_.store(true, std::memory_order_release);
 }
 
 void EndstoneScheduler::cancelTasks(Plugin &plugin)
@@ -122,7 +123,8 @@ void EndstoneScheduler::cancelTasks(Plugin &plugin)
     for (const auto &task : cancelling) {
         task->doCancel();
     }
-    purge_requested_.store(true, std::memory_order_release);
+    // CraftScheduler#cancelTasks queues a -1 task to purge queue_; we ask the main thread with a flag.
+    needs_purge_.store(true, std::memory_order_release);
 }
 
 bool EndstoneScheduler::isRunning(TaskId id)
@@ -199,7 +201,8 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
     current_tick = current_tick - *base_tick_ + 1;
     current_tick_.store(current_tick, std::memory_order_release);
 
-    if (purge_requested_.exchange(false, std::memory_order_acquire)) {
+    // CraftScheduler#parsePending runs the queued -1 purge tasks here; we coalesce them to one flag.
+    if (needs_purge_.exchange(false, std::memory_order_acquire)) {
         purgeCancelledTasks();
     }
 
@@ -271,8 +274,9 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
 
 void EndstoneScheduler::purgeCancelledTasks()
 {
-    // Main thread only: drop cancelled tasks from the pending and scheduled queues so their
-    // callbacks are released promptly.
+    // The needs_purge_ action, shared by the heartbeat and reload(): drop cancelled tasks from the
+    // pending and scheduled queues so their callbacks release promptly (before reload unloads the
+    // owning plugins). Main thread only, like everything that touches queue_.
     std::vector<std::shared_ptr<EndstoneTask>> pending;
     std::shared_ptr<EndstoneTask> task;
     while (pending_.try_dequeue(task)) {

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -95,8 +95,9 @@ void EndstoneScheduler::cancelTask(TaskId id)
     // Cancel outside the lock: an async task's doCancel() may call back into removeTask(),
     // which re-locks tasks_mtx_ and would deadlock if we still held it here.
     task->doCancel();
-    // CraftScheduler#cancelTask queues a -1 task to purge queue_; we ask the main thread with a flag.
-    needs_purge_.store(true, std::memory_order_release);
+    // CraftScheduler#cancelTask queues a -1 task to drop the cancelled task from queue_ on the main
+    // thread; we ask the main thread with a flag instead.
+    has_cancelled_tasks_.store(true, std::memory_order_release);
 }
 
 void EndstoneScheduler::cancelTasks(Plugin &plugin)
@@ -123,8 +124,9 @@ void EndstoneScheduler::cancelTasks(Plugin &plugin)
     for (const auto &task : cancelling) {
         task->doCancel();
     }
-    // CraftScheduler#cancelTasks queues a -1 task to purge queue_; we ask the main thread with a flag.
-    needs_purge_.store(true, std::memory_order_release);
+    // CraftScheduler#cancelTasks queues a -1 task to drop the cancelled tasks from queue_ on the main
+    // thread; we ask the main thread with a flag instead.
+    has_cancelled_tasks_.store(true, std::memory_order_release);
 }
 
 bool EndstoneScheduler::isRunning(TaskId id)
@@ -201,9 +203,9 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
     current_tick = current_tick - *base_tick_ + 1;
     current_tick_.store(current_tick, std::memory_order_release);
 
-    // CraftScheduler#parsePending runs the queued -1 purge tasks here; we coalesce them to one flag.
-    if (needs_purge_.exchange(false, std::memory_order_acquire)) {
-        purgeCancelledTasks();
+    // CraftScheduler#parsePending runs the queued -1 removal tasks here; we coalesce them to one flag.
+    if (has_cancelled_tasks_.exchange(false, std::memory_order_acquire)) {
+        removeCancelledTasks();
     }
 
     // Consume the tasks in the pending queue
@@ -247,14 +249,7 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
                 current_task_.store(0, std::memory_order_release);
             }
             else {
-                try {
-                    executor_.submit([task]() { task->run(); });
-                }
-                catch (std::exception &e) {
-                    task->doCancel();
-                    server_.getLogger().error("Could not submit task with id {}: {}", task->getTaskId(), e.what());
-                    continue;
-                }
+                executor_.submit([task]() { task->run(); });
             }
 
             if (!task->isCancelled() && task->getPeriod() > 0) {  // repeating task
@@ -272,9 +267,9 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
     }
 }
 
-void EndstoneScheduler::purgeCancelledTasks()
+void EndstoneScheduler::removeCancelledTasks()
 {
-    // The needs_purge_ action, shared by the heartbeat and reload(): drop cancelled tasks from the
+    // The has_cancelled_tasks_ action, shared by the heartbeat and reload(): drop cancelled tasks from the
     // pending and scheduled queues so their callbacks release promptly (before reload unloads the
     // owning plugins). Main thread only, like everything that touches queue_.
     std::vector<std::shared_ptr<EndstoneTask>> pending;

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -308,7 +308,7 @@ void EndstoneScheduler::removeTask(TaskId id)
     tasks_.erase(it);
 }
 
-std::vector<EndstoneAsyncTask::Worker> EndstoneScheduler::getActiveWorkers()
+std::vector<EndstoneWorker> EndstoneScheduler::getActiveWorkers()
 {
     std::vector<std::shared_ptr<EndstoneAsyncTask>> tasks;
     {
@@ -321,7 +321,7 @@ std::vector<EndstoneAsyncTask::Worker> EndstoneScheduler::getActiveWorkers()
     }
     // Query the workers outside the lock: getWorkers() takes the task's own mutex, which must
     // never be held together with tasks_mtx_ (see run()/doCancel()).
-    std::vector<EndstoneAsyncTask::Worker> workers;
+    std::vector<EndstoneWorker> workers;
     for (const auto &task : tasks) {
         auto task_workers = task->getWorkers();
         workers.insert(workers.end(), task_workers.begin(), task_workers.end());

--- a/src/endstone/core/scheduler/scheduler.cpp
+++ b/src/endstone/core/scheduler/scheduler.cpp
@@ -31,11 +31,6 @@ Result<void> validate(const Plugin &plugin, const std::function<void()> &task)
 
 EndstoneScheduler::EndstoneScheduler(Server &server) : server_(server) {}
 
-Logger &EndstoneScheduler::getLogger() const
-{
-    return server_.getLogger();
-}
-
 std::shared_ptr<Task> EndstoneScheduler::runTask(Plugin &plugin, std::function<void()> task)
 {
     return runTaskLater(plugin, task, 0);
@@ -54,7 +49,7 @@ std::shared_ptr<Task> EndstoneScheduler::runTaskTimer(Plugin &plugin, std::funct
     }
 
     auto t = std::make_shared<EndstoneTask>(*this, plugin, task, nextId(), period);
-    t->setNextRun(current_tick_.load(std::memory_order_relaxed) + delay);
+    t->setNextRun(current_tick_.load(std::memory_order_acquire) + delay);
     addTask(t);
     return t;
 }
@@ -78,7 +73,7 @@ std::shared_ptr<Task> EndstoneScheduler::runTaskTimerAsync(Plugin &plugin, std::
     }
 
     auto t = std::make_shared<EndstoneAsyncTask>(*this, plugin, task, nextId(), period);
-    t->setNextRun(current_tick_.load(std::memory_order_relaxed) + delay);
+    t->setNextRun(current_tick_.load(std::memory_order_acquire) + delay);
     addTask(t);
     return t;
 }
@@ -100,6 +95,7 @@ void EndstoneScheduler::cancelTask(TaskId id)
     // Cancel outside the lock: an async task's doCancel() may call back into removeTask(),
     // which re-locks tasks_mtx_ and would deadlock if we still held it here.
     task->doCancel();
+    purge_requested_.store(true, std::memory_order_release);
 }
 
 void EndstoneScheduler::cancelTasks(Plugin &plugin)
@@ -126,34 +122,7 @@ void EndstoneScheduler::cancelTasks(Plugin &plugin)
     for (const auto &task : cancelling) {
         task->doCancel();
     }
-
-    // Remove scheduler-owned references to cancelled plugin tasks from the
-    // pending and scheduled queues so their callbacks can be released promptly.
-    std::vector<std::shared_ptr<EndstoneTask>> pending;
-    std::shared_ptr<EndstoneTask> task;
-    while (pending_.try_dequeue(task)) {
-        if (task->getOwner() == &plugin) {
-            task.reset();
-        }
-        else {
-            pending.push_back(std::move(task));
-        }
-    }
-    for (auto &pending_task : pending) {
-        pending_.enqueue(std::move(pending_task));
-    }
-
-    for (auto it = queue_.begin(); it != queue_.end();) {
-        auto &tasks = it->second;
-        std::erase_if(tasks, [&plugin](const auto &queued) { return queued->getOwner() == &plugin; });
-        if (tasks.empty()) {
-            it = queue_.erase(it);
-        }
-        else {
-            std::make_heap(tasks.begin(), tasks.end(), cmp_);
-            ++it;
-        }
-    }
+    purge_requested_.store(true, std::memory_order_release);
 }
 
 bool EndstoneScheduler::isRunning(TaskId id)
@@ -167,7 +136,7 @@ bool EndstoneScheduler::isRunning(TaskId id)
         }
         task = it->second;
         if (task->isSync()) {
-            return current_task_ == id;
+            return current_task_.load(std::memory_order_acquire) == id;
         }
     }
     // Query the workers outside the lock: getWorkers() takes the task's own mutex, which must
@@ -200,7 +169,7 @@ std::shared_ptr<Task> EndstoneScheduler::runTask(std::function<void()> task)
         return nullptr;
     }
     auto t = std::make_shared<EndstoneTask>(*this, task, nextId(), 0);
-    t->setNextRun(current_tick_.load(std::memory_order_relaxed));
+    t->setNextRun(current_tick_.load(std::memory_order_acquire));
     addTask(t);
     return t;
 }
@@ -228,7 +197,11 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
     // +1 so the first heartbeat is tick 1: the counter advances 0 -> 1 on the first tick, matching
     // the contract that a task registered with delay N runs on the Nth tick.
     current_tick = current_tick - *base_tick_ + 1;
-    current_tick_.store(current_tick, std::memory_order_relaxed);
+    current_tick_.store(current_tick, std::memory_order_release);
+
+    if (purge_requested_.exchange(false, std::memory_order_acquire)) {
+        purgeCancelledTasks();
+    }
 
     // Consume the tasks in the pending queue
     std::shared_ptr<EndstoneTask> pending_task;
@@ -261,18 +234,14 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
             }
 
             if (task->isSync()) {
-                current_task_ = task->getTaskId();
+                current_task_.store(task->getTaskId(), std::memory_order_release);
                 try {
                     task->run();
                 }
                 catch (std::exception &e) {
                     server_.getLogger().error("Could not execute task with id {}: {}", task->getTaskId(), e.what());
                 }
-                catch (...) {
-                    server_.getLogger().error("Could not execute task with id {}: unknown exception",
-                                              task->getTaskId());
-                }
-                current_task_ = 0;
+                current_task_.store(0, std::memory_order_release);
             }
             else {
                 try {
@@ -283,14 +252,9 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
                     server_.getLogger().error("Could not submit task with id {}: {}", task->getTaskId(), e.what());
                     continue;
                 }
-                catch (...) {
-                    task->doCancel();
-                    server_.getLogger().error("Could not submit task with id {}: unknown exception", task->getTaskId());
-                    continue;
-                }
             }
 
-            if (task->getPeriod() > 0) {  // repeating task
+            if (!task->isCancelled() && task->getPeriod() > 0) {  // repeating task
                 task->setNextRun(current_tick + task->getPeriod());
                 pending_.enqueue(task);
                 continue;
@@ -305,6 +269,35 @@ void EndstoneScheduler::mainThreadHeartbeat(std::uint64_t current_tick)
     }
 }
 
+void EndstoneScheduler::purgeCancelledTasks()
+{
+    // Main thread only: drop cancelled tasks from the pending and scheduled queues so their
+    // callbacks are released promptly.
+    std::vector<std::shared_ptr<EndstoneTask>> pending;
+    std::shared_ptr<EndstoneTask> task;
+    while (pending_.try_dequeue(task)) {
+        if (!task->isCancelled()) {
+            pending.push_back(std::move(task));
+        }
+    }
+    task.reset();
+    for (auto &pending_task : pending) {
+        pending_.enqueue(std::move(pending_task));
+    }
+
+    for (auto it = queue_.begin(); it != queue_.end();) {
+        auto &tasks = it->second;
+        std::erase_if(tasks, [](const auto &queued) { return queued->isCancelled(); });
+        if (tasks.empty()) {
+            it = queue_.erase(it);
+        }
+        else {
+            std::make_heap(tasks.begin(), tasks.end(), cmp_);
+            ++it;
+        }
+    }
+}
+
 void EndstoneScheduler::removeTask(TaskId id)
 {
     std::lock_guard lock{tasks_mtx_};
@@ -315,22 +308,25 @@ void EndstoneScheduler::removeTask(TaskId id)
     tasks_.erase(it);
 }
 
-void EndstoneScheduler::waitForAsyncTasks(Plugin &plugin)
+std::vector<EndstoneAsyncTask::Worker> EndstoneScheduler::getActiveWorkers()
 {
     std::vector<std::shared_ptr<EndstoneAsyncTask>> tasks;
     {
         std::lock_guard lock{tasks_mtx_};
-        for (const auto &entry : tasks_) {
-            const auto &task = entry.second;
-            if (!task->isSync() && task->getOwner() == &plugin) {
+        for (const auto &[id, task] : tasks_) {
+            if (!task->isSync()) {
                 tasks.push_back(std::static_pointer_cast<EndstoneAsyncTask>(task));
             }
         }
     }
+    // Query the workers outside the lock: getWorkers() takes the task's own mutex, which must
+    // never be held together with tasks_mtx_ (see run()/doCancel()).
+    std::vector<EndstoneAsyncTask::Worker> workers;
     for (const auto &task : tasks) {
-        task->wait();
+        auto task_workers = task->getWorkers();
+        workers.insert(workers.end(), task_workers.begin(), task_workers.end());
     }
-    executor_.wait();
+    return workers;
 }
 
 TaskId EndstoneScheduler::nextId()

--- a/src/endstone/core/scheduler/scheduler.h
+++ b/src/endstone/core/scheduler/scheduler.h
@@ -48,6 +48,7 @@ public:
 
     std::shared_ptr<Task> runTask(std::function<void()> task);
     void addTask(std::shared_ptr<EndstoneTask> task);
+    Logger &getLogger() const;
     void mainThreadHeartbeat(std::uint64_t current_tick);
     void removeTask(TaskId id);
     void waitForAsyncTasks(Plugin &plugin);

--- a/src/endstone/core/scheduler/scheduler.h
+++ b/src/endstone/core/scheduler/scheduler.h
@@ -66,7 +66,7 @@ private:
     std::mutex tasks_mtx_{};
     std::map<std::uint64_t, std::vector<std::shared_ptr<EndstoneTask>>> queue_{};
     std::optional<std::uint64_t> base_tick_{};
-    std::uint64_t current_tick_{0};
+    std::atomic<std::uint64_t> current_tick_{0};
     std::atomic<TaskId> current_task_{0};
     TaskComparator cmp_{};
     ThreadPoolExecutor executor_;

--- a/src/endstone/core/scheduler/scheduler.h
+++ b/src/endstone/core/scheduler/scheduler.h
@@ -50,6 +50,7 @@ public:
     void addTask(std::shared_ptr<EndstoneTask> task);
     void mainThreadHeartbeat(std::uint64_t current_tick);
     void removeTask(TaskId id);
+    void waitForAsyncTasks(Plugin &plugin);
 
 private:
     TaskId nextId();

--- a/src/endstone/core/scheduler/scheduler.h
+++ b/src/endstone/core/scheduler/scheduler.h
@@ -52,7 +52,7 @@ public:
     void addTask(std::shared_ptr<EndstoneTask> task);
     void mainThreadHeartbeat(std::uint64_t current_tick);
     void removeTask(TaskId id);
-    void purgeCancelledTasks();
+    void removeCancelledTasks();
     std::vector<EndstoneWorker> getActiveWorkers();
 
 private:
@@ -72,10 +72,10 @@ private:
     std::atomic<std::uint64_t> current_tick_{0};
     std::atomic<TaskId> current_task_{0};
     // Set by cancelTask/cancelTasks on any thread, consumed by the main thread each heartbeat. The
-    // boolean stand-in for CraftScheduler queuing a -1 task to purge cancelled tasks from queue_; a
+    // boolean stand-in for CraftScheduler queuing a -1 task to remove cancelled tasks from queue_; a
     // flag suffices because the heartbeat is our one main-thread entry point. atomic (Bukkit's
     // volatile) carries the cross-thread visibility, like current_tick_/current_task_.
-    std::atomic<bool> needs_purge_{false};
+    std::atomic<bool> has_cancelled_tasks_{false};
     TaskComparator cmp_{};
     ThreadPoolExecutor executor_;
 };

--- a/src/endstone/core/scheduler/scheduler.h
+++ b/src/endstone/core/scheduler/scheduler.h
@@ -22,6 +22,7 @@
 
 #include <moodycamel/concurrentqueue.h>
 
+#include "endstone/core/scheduler/async_task.h"
 #include "endstone/core/scheduler/task.h"
 #include "endstone/core/scheduler/thread_pool_executor.h"
 #include "endstone/scheduler/scheduler.h"
@@ -48,10 +49,10 @@ public:
 
     std::shared_ptr<Task> runTask(std::function<void()> task);
     void addTask(std::shared_ptr<EndstoneTask> task);
-    Logger &getLogger() const;
     void mainThreadHeartbeat(std::uint64_t current_tick);
     void removeTask(TaskId id);
-    void waitForAsyncTasks(Plugin &plugin);
+    void purgeCancelledTasks();
+    std::vector<EndstoneAsyncTask::Worker> getActiveWorkers();
 
 private:
     TaskId nextId();
@@ -69,6 +70,7 @@ private:
     std::optional<std::uint64_t> base_tick_{};
     std::atomic<std::uint64_t> current_tick_{0};
     std::atomic<TaskId> current_task_{0};
+    std::atomic<bool> purge_requested_{false};
     TaskComparator cmp_{};
     ThreadPoolExecutor executor_;
 };

--- a/src/endstone/core/scheduler/scheduler.h
+++ b/src/endstone/core/scheduler/scheduler.h
@@ -71,7 +71,11 @@ private:
     std::optional<std::uint64_t> base_tick_{};
     std::atomic<std::uint64_t> current_tick_{0};
     std::atomic<TaskId> current_task_{0};
-    std::atomic<bool> purge_requested_{false};
+    // Set by cancelTask/cancelTasks on any thread, consumed by the main thread each heartbeat. The
+    // boolean stand-in for CraftScheduler queuing a -1 task to purge cancelled tasks from queue_; a
+    // flag suffices because the heartbeat is our one main-thread entry point. atomic (Bukkit's
+    // volatile) carries the cross-thread visibility, like current_tick_/current_task_.
+    std::atomic<bool> needs_purge_{false};
     TaskComparator cmp_{};
     ThreadPoolExecutor executor_;
 };

--- a/src/endstone/core/scheduler/scheduler.h
+++ b/src/endstone/core/scheduler/scheduler.h
@@ -25,6 +25,7 @@
 #include "endstone/core/scheduler/async_task.h"
 #include "endstone/core/scheduler/task.h"
 #include "endstone/core/scheduler/thread_pool_executor.h"
+#include "endstone/core/scheduler/worker.h"
 #include "endstone/scheduler/scheduler.h"
 
 namespace endstone::core {
@@ -52,7 +53,7 @@ public:
     void mainThreadHeartbeat(std::uint64_t current_tick);
     void removeTask(TaskId id);
     void purgeCancelledTasks();
-    std::vector<EndstoneAsyncTask::Worker> getActiveWorkers();
+    std::vector<EndstoneWorker> getActiveWorkers();
 
 private:
     TaskId nextId();

--- a/src/endstone/core/scheduler/task.cpp
+++ b/src/endstone/core/scheduler/task.cpp
@@ -49,7 +49,7 @@ bool EndstoneTask::isSync() const
 
 bool EndstoneTask::isCancelled() const
 {
-    return cancelled_;
+    return cancelled_.load(std::memory_order_acquire);
 }
 
 void EndstoneTask::cancel()
@@ -66,7 +66,7 @@ void EndstoneTask::run()
 
 void EndstoneTask::doCancel()
 {
-    cancelled_ = true;
+    cancelled_.store(true, std::memory_order_release);
 }
 
 EndstoneScheduler &EndstoneTask::getScheduler() const

--- a/src/endstone/core/scheduler/task.h
+++ b/src/endstone/core/scheduler/task.h
@@ -51,7 +51,7 @@ public:
 
 private:
     EndstoneScheduler &scheduler_;
-    Plugin *plugin_;
+    Plugin *plugin_{nullptr};
     std::function<void()> task_;
     TaskId id_;
     CreatedAt created_at_{TaskClock::now()};

--- a/src/endstone/core/scheduler/task.h
+++ b/src/endstone/core/scheduler/task.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 

--- a/src/endstone/core/scheduler/thread_pool_executor.cpp
+++ b/src/endstone/core/scheduler/thread_pool_executor.cpp
@@ -14,10 +14,13 @@
 
 #include "endstone/core/scheduler/thread_pool_executor.h"
 
+#include <algorithm>
+
 namespace endstone::core {
 
 ThreadPoolExecutor::ThreadPoolExecutor(size_t thread_count) : done(false)
 {
+    thread_count = std::max<std::size_t>(thread_count, 1);
     for (size_t i = 0; i < thread_count; ++i) {
         threads.emplace_back(&ThreadPoolExecutor::worker, this);
     }

--- a/src/endstone/core/scheduler/thread_pool_executor.cpp
+++ b/src/endstone/core/scheduler/thread_pool_executor.cpp
@@ -37,12 +37,24 @@ ThreadPoolExecutor::~ThreadPoolExecutor()
     }
 }
 
+void ThreadPoolExecutor::wait()
+{
+    std::unique_lock lock{mutex};
+    condition.wait(lock, [this]() { return pending_tasks == 0; });
+}
+
 void ThreadPoolExecutor::worker()
 {
     while (!done) {
         std::function<void()> task;
         if (tasks.try_dequeue(task)) {
             task();
+            task = {};
+            {
+                std::lock_guard lock{mutex};
+                --pending_tasks;
+            }
+            condition.notify_all();
         }
         else {
             std::unique_lock<std::mutex> lock(mutex);
@@ -54,6 +66,12 @@ void ThreadPoolExecutor::worker()
     std::function<void()> task;
     while (tasks.try_dequeue(task)) {
         task();
+        task = {};
+        {
+            std::lock_guard lock{mutex};
+            --pending_tasks;
+        }
+        condition.notify_all();
     }
 }
 }  // namespace endstone::core

--- a/src/endstone/core/scheduler/thread_pool_executor.cpp
+++ b/src/endstone/core/scheduler/thread_pool_executor.cpp
@@ -15,6 +15,7 @@
 #include "endstone/core/scheduler/thread_pool_executor.h"
 
 #include <algorithm>
+#include <chrono>
 
 namespace endstone::core {
 

--- a/src/endstone/core/scheduler/thread_pool_executor.cpp
+++ b/src/endstone/core/scheduler/thread_pool_executor.cpp
@@ -38,12 +38,6 @@ ThreadPoolExecutor::~ThreadPoolExecutor()
     }
 }
 
-void ThreadPoolExecutor::wait()
-{
-    std::unique_lock lock{mutex};
-    condition.wait(lock, [this]() { return pending_tasks == 0; });
-}
-
 void ThreadPoolExecutor::worker()
 {
     while (!done) {
@@ -51,11 +45,6 @@ void ThreadPoolExecutor::worker()
         if (tasks.try_dequeue(task)) {
             task();
             task = {};
-            {
-                std::lock_guard lock{mutex};
-                --pending_tasks;
-            }
-            condition.notify_all();
         }
         else {
             std::unique_lock<std::mutex> lock(mutex);
@@ -67,12 +56,6 @@ void ThreadPoolExecutor::worker()
     std::function<void()> task;
     while (tasks.try_dequeue(task)) {
         task();
-        task = {};
-        {
-            std::lock_guard lock{mutex};
-            --pending_tasks;
-        }
-        condition.notify_all();
     }
 }
 }  // namespace endstone::core

--- a/src/endstone/core/scheduler/thread_pool_executor.h
+++ b/src/endstone/core/scheduler/thread_pool_executor.h
@@ -17,8 +17,10 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <future>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
 #include <vector>

--- a/src/endstone/core/scheduler/thread_pool_executor.h
+++ b/src/endstone/core/scheduler/thread_pool_executor.h
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <functional>
 #include <future>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -42,8 +43,19 @@ public:
         auto result = task->get_future();
         {
             std::lock_guard lock{mutex};
-            tasks.enqueue([task]() { (*task)(); });
             ++pending_tasks;
+            try {
+                if (!tasks.enqueue([task]() { (*task)(); })) {
+                    throw std::runtime_error("Failed to enqueue task");
+                }
+            }
+            catch (...) {
+                --pending_tasks;
+                if (pending_tasks == 0) {
+                    condition.notify_all();
+                }
+                throw;
+            }
         }
 
         condition.notify_one();

--- a/src/endstone/core/scheduler/thread_pool_executor.h
+++ b/src/endstone/core/scheduler/thread_pool_executor.h
@@ -40,11 +40,17 @@ public:
             std::bind(std::forward<Func>(func), std::forward<Args>(args)...));
 
         auto result = task->get_future();
-        tasks.enqueue([task]() { (*task)(); });
+        {
+            std::lock_guard lock{mutex};
+            tasks.enqueue([task]() { (*task)(); });
+            ++pending_tasks;
+        }
 
         condition.notify_one();
         return result;
     }
+
+    void wait();
 
 private:
     void worker();
@@ -54,6 +60,7 @@ private:
     std::atomic<bool> done;
     std::mutex mutex;
     std::condition_variable condition;
+    std::size_t pending_tasks{0};
 };
 
 }  // namespace endstone::core

--- a/src/endstone/core/scheduler/thread_pool_executor.h
+++ b/src/endstone/core/scheduler/thread_pool_executor.h
@@ -14,14 +14,11 @@
 
 #pragma once
 
-#pragma once
-
 #include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <future>
 #include <mutex>
-#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -43,10 +40,7 @@ public:
             std::bind(std::forward<Func>(func), std::forward<Args>(args)...));
 
         auto result = task->get_future();
-        if (!tasks.enqueue([task]() { (*task)(); })) {
-            throw std::runtime_error("Failed to enqueue task");
-        }
-
+        tasks.enqueue([task]() { (*task)(); });
         condition.notify_one();
         return result;
     }

--- a/src/endstone/core/scheduler/thread_pool_executor.h
+++ b/src/endstone/core/scheduler/thread_pool_executor.h
@@ -43,28 +43,13 @@ public:
             std::bind(std::forward<Func>(func), std::forward<Args>(args)...));
 
         auto result = task->get_future();
-        {
-            std::lock_guard lock{mutex};
-            ++pending_tasks;
-            try {
-                if (!tasks.enqueue([task]() { (*task)(); })) {
-                    throw std::runtime_error("Failed to enqueue task");
-                }
-            }
-            catch (...) {
-                --pending_tasks;
-                if (pending_tasks == 0) {
-                    condition.notify_all();
-                }
-                throw;
-            }
+        if (!tasks.enqueue([task]() { (*task)(); })) {
+            throw std::runtime_error("Failed to enqueue task");
         }
 
         condition.notify_one();
         return result;
     }
-
-    void wait();
 
 private:
     void worker();
@@ -74,7 +59,6 @@ private:
     std::atomic<bool> done;
     std::mutex mutex;
     std::condition_variable condition;
-    std::size_t pending_tasks{0};
 };
 
 }  // namespace endstone::core

--- a/src/endstone/core/scheduler/worker.h
+++ b/src/endstone/core/scheduler/worker.h
@@ -14,27 +14,16 @@
 
 #pragma once
 
-#include <mutex>
-#include <vector>
+#include <thread>
 
-#include "endstone/core/scheduler/task.h"
-#include "endstone/core/scheduler/worker.h"
+#include "endstone/scheduler/task.h"
 
 namespace endstone::core {
 
-class EndstoneAsyncTask : public EndstoneTask {
-public:
-    using EndstoneTask::EndstoneTask;
-    [[nodiscard]] bool isSync() const override;
-
-    void run() override;
-    void doCancel() override;
-
-    std::vector<EndstoneWorker> getWorkers() const;
-
-private:
-    mutable std::mutex mutex_;
-    std::vector<EndstoneWorker> workers_;
+struct EndstoneWorker {
+    std::thread::id thread_id;
+    TaskId task_id;
+    Plugin *owner_;
 };
 
 }  // namespace endstone::core

--- a/src/endstone/core/server.cpp
+++ b/src/endstone/core/server.cpp
@@ -15,11 +15,13 @@
 #include "endstone/core/server.h"
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <format>
 #include <iostream>
 #include <memory>
 #include <ranges>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -487,10 +489,27 @@ void EndstoneServer::shutdown()
 void EndstoneServer::reload()
 {
     command_map_->clearCommands();
+
+    // Wait for at most 2.5 seconds for plugins to close their async tasks
+    plugin_manager_->disablePlugins();
+    auto &scheduler = static_cast<EndstoneScheduler &>(getScheduler());
+    for (int poll_count = 0; poll_count < 50 && !scheduler.getActiveWorkers().empty(); ++poll_count) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    for (const auto &worker : scheduler.getActiveWorkers()) {
+        const auto &description = worker.owner_->getDescription();
+        std::string authors;
+        for (const auto &author : description.getAuthors()) {
+            authors += authors.empty() ? author : ", " + author;
+        }
+        getLogger().error("Nag author(s): '{}' of '{}' about the following: {}", authors, description.getFullName(),
+                          "This plugin is not properly shutting down its async tasks when it is being reloaded. This "
+                          "may cause conflicts with the newly loaded version of the plugin");
+    }
+    scheduler.purgeCancelledTasks();
+
     plugin_manager_->clearPlugins();
     reloadData();
-
-    // TODO(server): Wait for at most 2.5 seconds for all async tasks to finish, otherwise issue a warning
     loadPlugins();
     enablePlugins(PluginLoadOrder::Startup);
     enablePlugins(PluginLoadOrder::PostWorld);

--- a/src/endstone/core/server.cpp
+++ b/src/endstone/core/server.cpp
@@ -72,6 +72,7 @@
 #include "endstone/event/server/server_load_event.h"
 #include "endstone/plugin/plugin.h"
 #include "endstone/runtime/runtime.h"
+#include "endstone/util/format.h"
 
 namespace fs = std::filesystem;
 namespace py = pybind11;
@@ -498,15 +499,12 @@ void EndstoneServer::reload()
     }
     for (const auto &worker : scheduler.getActiveWorkers()) {
         const auto &description = worker.owner_->getDescription();
-        std::string authors;
-        for (const auto &author : description.getAuthors()) {
-            authors += authors.empty() ? author : ", " + author;
-        }
-        getLogger().error("Nag author(s): '{}' of '{}' about the following: {}", authors, description.getFullName(),
+        getLogger().error("Nag author(s): '{}' of '{}' about the following: {}",
+                          detail::join(description.getAuthors(), ", "), description.getFullName(),
                           "This plugin is not properly shutting down its async tasks when it is being reloaded. This "
                           "may cause conflicts with the newly loaded version of the plugin");
     }
-    scheduler.purgeCancelledTasks();
+    scheduler.removeCancelledTasks();
 
     plugin_manager_->clearPlugins();
     reloadData();

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -171,6 +171,87 @@ TEST_F(SchedulerTest, CancelAsyncTasksDoesNotDeadlock)
     EXPECT_FALSE(scheduler_->isQueued(task2->getTaskId()));
 }
 
+TEST_F(SchedulerTest, CancelRunningAsyncTask)
+{
+    std::promise<void> started;
+    std::promise<void> release;
+    std::promise<void> finished;
+    auto started_future = started.get_future();
+    auto release_future = release.get_future().share();
+    auto finished_future = finished.get_future();
+    auto task = scheduler_->runTaskAsync(plugin_, [&]() {
+        started.set_value();
+        release_future.wait();
+        finished.set_value();
+    });
+    ASSERT_TRUE(task != nullptr);
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        release.set_value();
+        FAIL() << "Async task did not start";
+    }
+
+    scheduler_->cancelTasks(plugin_);
+
+    EXPECT_TRUE(scheduler_->isRunning(task->getTaskId()));
+    release.set_value();
+    ASSERT_EQ(finished_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (scheduler_->isRunning(task->getTaskId()) && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
+}
+
+TEST_F(SchedulerTest, CancelledAsyncTaskDoesNotStart)
+{
+    const auto thread_count = std::thread::hardware_concurrency();
+    if (thread_count == 0) {
+        GTEST_SKIP() << "No executor threads available";
+    }
+
+    std::atomic<unsigned int> started_count{0};
+    std::atomic<unsigned int> finished_count{0};
+    std::promise<void> all_started;
+    std::promise<void> all_finished;
+    std::promise<void> release;
+    auto all_started_future = all_started.get_future();
+    auto all_finished_future = all_finished.get_future();
+    auto release_future = release.get_future().share();
+    for (unsigned int i = 0; i < thread_count; ++i) {
+        scheduler_->runTaskAsync(plugin_, [&]() {
+            if (started_count.fetch_add(1) + 1 == thread_count) {
+                all_started.set_value();
+            }
+            release_future.wait();
+            if (finished_count.fetch_add(1) + 1 == thread_count) {
+                all_finished.set_value();
+            }
+        });
+    }
+
+    std::atomic<bool> cancelled_task_started{false};
+    scheduler_->runTaskAsync(plugin_, [&]() { cancelled_task_started = true; });
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    if (all_started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        release.set_value();
+        FAIL() << "Executor workers did not start";
+    }
+
+    scheduler_->cancelTasks(plugin_);
+    release.set_value();
+    ASSERT_EQ(all_finished_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    std::promise<void> drained;
+    auto drained_future = drained.get_future();
+    scheduler_->runTaskAsync(plugin_, [&]() { drained.set_value(); });
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    ASSERT_EQ(drained_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    EXPECT_FALSE(cancelled_task_started);
+}
+
 // Test to check if a task is running
 TEST_F(SchedulerTest, TaskIsRunning)
 {

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -293,12 +293,7 @@ TEST_F(SchedulerTest, CancelledAsyncTaskDoesNotStart)
     scheduler_->cancelTasks(plugin_);
     release.set_value();
     ASSERT_EQ(all_finished_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
-
-    std::promise<void> drained;
-    auto drained_future = drained.get_future();
-    scheduler_->runTaskAsync(plugin_, [&]() { drained.set_value(); });
-    scheduler_->mainThreadHeartbeat(++tick_count_);
-    ASSERT_EQ(drained_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    scheduler_->waitForAsyncTasks(plugin_);
     EXPECT_FALSE(cancelled_task_started);
 }
 

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <future>
 #include <memory>
 #include <string>
 #include <vector>
@@ -55,6 +56,19 @@ TEST_F(SchedulerTest, RunTask)
     EXPECT_FALSE(executed);
     scheduler_->mainThreadHeartbeat(++tick_count_);
     EXPECT_TRUE(executed);
+}
+
+TEST_F(SchedulerTest, RunTaskAsync)
+{
+    std::promise<void> executed;
+    auto future = executed.get_future();
+    auto task = scheduler_->runTaskAsync(plugin_, [&]() { executed.set_value(); });
+    ASSERT_TRUE(task != nullptr);
+    task.reset();
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+
+    EXPECT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
 }
 
 // Test running a task later

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -252,6 +252,39 @@ TEST_F(SchedulerTest, CancelledAsyncTaskDoesNotStart)
     EXPECT_FALSE(cancelled_task_started);
 }
 
+TEST_F(SchedulerTest, WaitForAsyncTasks)
+{
+    std::promise<void> started;
+    std::promise<void> release;
+    std::promise<void> allow_release;
+    auto started_future = started.get_future();
+    auto release_future = release.get_future().share();
+    auto allow_release_future = allow_release.get_future();
+    auto task = scheduler_->runTaskAsync(plugin_, [&]() {
+        started.set_value();
+        release_future.wait();
+    });
+    ASSERT_TRUE(task != nullptr);
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        release.set_value();
+        FAIL() << "Async task did not start";
+    }
+
+    scheduler_->cancelTasks(plugin_);
+    EXPECT_TRUE(scheduler_->isRunning(task->getTaskId()));
+    std::jthread releaser([&]() {
+        allow_release_future.wait();
+        release.set_value();
+    });
+
+    allow_release.set_value();
+    scheduler_->waitForAsyncTasks(plugin_);
+
+    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
+}
+
 // Test to check if a task is running
 TEST_F(SchedulerTest, TaskIsRunning)
 {

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -140,6 +140,24 @@ TEST_F(SchedulerTest, CancelTasks)
     EXPECT_FALSE(scheduler_->isQueued(task3->getTaskId()));
 }
 
+TEST_F(SchedulerTest, CancelTasksKeepsInternalTasks)
+{
+    bool internal_executed = false;
+    bool plugin_executed = false;
+    auto internal_task = scheduler_->runTask([&]() { internal_executed = true; });
+    auto plugin_task = scheduler_->runTask(plugin_, [&]() { plugin_executed = true; });
+    ASSERT_TRUE(internal_task != nullptr);
+    ASSERT_TRUE(plugin_task != nullptr);
+
+    scheduler_->cancelTasks(plugin_);
+
+    EXPECT_TRUE(scheduler_->isQueued(internal_task->getTaskId()));
+    EXPECT_FALSE(scheduler_->isQueued(plugin_task->getTaskId()));
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    EXPECT_TRUE(internal_executed);
+    EXPECT_FALSE(plugin_executed);
+}
+
 // Regression test for #351: cancelling an idle async task via cancelTasks() used to re-lock
 // tasks_mtx_ recursively (doCancel() -> removeTask()), throwing "resource deadlock would occur".
 TEST_F(SchedulerTest, CancelAsyncTasksDoesNotDeadlock)

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -59,6 +59,23 @@ TEST_F(SchedulerTest, RunTask)
     EXPECT_TRUE(executed);
 }
 
+TEST_F(SchedulerTest, RunInternalTaskFromAnotherThread)
+{
+    bool executed = false;
+    std::promise<std::shared_ptr<endstone::Task>> registered;
+    auto registered_future = registered.get_future();
+    std::jthread thread([&]() { registered.set_value(scheduler_->runTask([&]() { executed = true; })); });
+    auto task = registered_future.get();
+    thread.join();
+    ASSERT_TRUE(task != nullptr);
+    EXPECT_TRUE(scheduler_->isQueued(task->getTaskId()));
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+
+    EXPECT_TRUE(executed);
+    EXPECT_FALSE(scheduler_->isQueued(task->getTaskId()));
+}
+
 TEST_F(SchedulerTest, RunTaskAsync)
 {
     std::promise<void> executed;

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -106,6 +106,8 @@ TEST_F(SchedulerTest, SyncTaskRecoversFromUnknownException)
 
 TEST_F(SchedulerTest, AsyncTaskRecoversFromUnknownException)
 {
+    EXPECT_CALL(server_, getLogger())
+        .WillOnce(testing::ReturnRef(endstone::core::LoggerFactory::getLogger("SchedulerTest")));
     std::promise<void> started;
     auto started_future = started.get_future();
     auto task = scheduler_->runTaskAsync(plugin_, [&]() {

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -85,6 +85,19 @@ TEST_F(SchedulerTest, RunTaskLater)
     EXPECT_TRUE(executed);
 }
 
+TEST_F(SchedulerTest, RunTaskLaterFromCallback)
+{
+    bool executed = false;
+    scheduler_->runTask(plugin_, [&]() { scheduler_->runTaskLater(plugin_, [&]() { executed = true; }, 2); });
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    EXPECT_FALSE(executed);
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    EXPECT_FALSE(executed);
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    EXPECT_TRUE(executed);
+}
+
 // Regression test for #317: a delayed task registered before the first heartbeat (e.g. in
 // Plugin::onEnable / ServerLoadEvent) must honour its delay even when the world's persisted server
 // tick is already large. The scheduler normalises ticks to a zero-based, session-relative clock.

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -185,6 +185,38 @@ TEST_F(SchedulerTest, TaskIsRunning)
     EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
 }
 
+TEST_F(SchedulerTest, AsyncTaskIsRunning)
+{
+    std::promise<void> started;
+    std::promise<void> release;
+    std::promise<void> finished;
+    auto started_future = started.get_future();
+    auto release_future = release.get_future().share();
+    auto finished_future = finished.get_future();
+    auto task = scheduler_->runTaskAsync(plugin_, [&]() {
+        started.set_value();
+        release_future.wait();
+        finished.set_value();
+    });
+    ASSERT_TRUE(task != nullptr);
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+
+    if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        release.set_value();
+        FAIL() << "Async task did not start";
+    }
+    EXPECT_TRUE(scheduler_->isRunning(task->getTaskId()));
+    release.set_value();
+    ASSERT_EQ(finished_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (scheduler_->isRunning(task->getTaskId()) && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
+}
+
 // Test to check if a task is queued
 TEST_F(SchedulerTest, TaskIsQueued)
 {

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "endstone/core/logger_factory.h"
 #include "endstone/core/scheduler/scheduler.h"
 #include "mocks.h"
 
@@ -69,6 +70,42 @@ TEST_F(SchedulerTest, RunTaskAsync)
     scheduler_->mainThreadHeartbeat(++tick_count_);
 
     EXPECT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+}
+
+TEST_F(SchedulerTest, SyncTaskRecoversFromUnknownException)
+{
+    EXPECT_CALL(server_, getLogger())
+        .WillOnce(testing::ReturnRef(endstone::core::LoggerFactory::getLogger("SchedulerTest")));
+    bool next_executed = false;
+    auto task = scheduler_->runTask(plugin_, []() { throw 42; });
+    scheduler_->runTask(plugin_, [&]() { next_executed = true; });
+    ASSERT_TRUE(task != nullptr);
+
+    EXPECT_NO_THROW(scheduler_->mainThreadHeartbeat(++tick_count_));
+
+    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
+    EXPECT_TRUE(next_executed);
+}
+
+TEST_F(SchedulerTest, AsyncTaskRecoversFromUnknownException)
+{
+    std::promise<void> started;
+    auto started_future = started.get_future();
+    auto task = scheduler_->runTaskAsync(plugin_, [&]() {
+        started.set_value();
+        throw 42;
+    });
+    ASSERT_TRUE(task != nullptr);
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    ASSERT_EQ(started_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (scheduler_->isRunning(task->getTaskId()) && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
+    EXPECT_FALSE(scheduler_->isQueued(task->getTaskId()));
 }
 
 // Test running a task later

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <future>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "endstone/core/logger_factory.h"
 #include "endstone/core/scheduler/scheduler.h"
 #include "mocks.h"
 
@@ -59,23 +60,6 @@ TEST_F(SchedulerTest, RunTask)
     EXPECT_TRUE(executed);
 }
 
-TEST_F(SchedulerTest, RunInternalTaskFromAnotherThread)
-{
-    bool executed = false;
-    std::promise<std::shared_ptr<endstone::Task>> registered;
-    auto registered_future = registered.get_future();
-    std::jthread thread([&]() { registered.set_value(scheduler_->runTask([&]() { executed = true; })); });
-    auto task = registered_future.get();
-    thread.join();
-    ASSERT_TRUE(task != nullptr);
-    EXPECT_TRUE(scheduler_->isQueued(task->getTaskId()));
-
-    scheduler_->mainThreadHeartbeat(++tick_count_);
-
-    EXPECT_TRUE(executed);
-    EXPECT_FALSE(scheduler_->isQueued(task->getTaskId()));
-}
-
 TEST_F(SchedulerTest, RunTaskAsync)
 {
     std::promise<void> executed;
@@ -86,45 +70,11 @@ TEST_F(SchedulerTest, RunTaskAsync)
 
     scheduler_->mainThreadHeartbeat(++tick_count_);
 
-    EXPECT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
-}
-
-TEST_F(SchedulerTest, SyncTaskRecoversFromUnknownException)
-{
-    EXPECT_CALL(server_, getLogger())
-        .WillOnce(testing::ReturnRef(endstone::core::LoggerFactory::getLogger("SchedulerTest")));
-    bool next_executed = false;
-    auto task = scheduler_->runTask(plugin_, []() { throw 42; });
-    scheduler_->runTask(plugin_, [&]() { next_executed = true; });
-    ASSERT_TRUE(task != nullptr);
-
-    EXPECT_NO_THROW(scheduler_->mainThreadHeartbeat(++tick_count_));
-
-    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
-    EXPECT_TRUE(next_executed);
-}
-
-TEST_F(SchedulerTest, AsyncTaskRecoversFromUnknownException)
-{
-    EXPECT_CALL(server_, getLogger())
-        .WillOnce(testing::ReturnRef(endstone::core::LoggerFactory::getLogger("SchedulerTest")));
-    std::promise<void> started;
-    auto started_future = started.get_future();
-    auto task = scheduler_->runTaskAsync(plugin_, [&]() {
-        started.set_value();
-        throw 42;
-    });
-    ASSERT_TRUE(task != nullptr);
-
-    scheduler_->mainThreadHeartbeat(++tick_count_);
-    ASSERT_EQ(started_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
-
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-    while (scheduler_->isRunning(task->getTaskId()) && std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::yield();
+    if (future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        // Quiesce before the stack captures die, or the executor drain runs a dangling lambda.
+        scheduler_.reset();
+        FAIL() << "Async task did not run";
     }
-    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
-    EXPECT_FALSE(scheduler_->isQueued(task->getTaskId()));
 }
 
 // Test running a task later
@@ -141,6 +91,8 @@ TEST_F(SchedulerTest, RunTaskLater)
     EXPECT_TRUE(executed);
 }
 
+// Regression test for #436: a delay scheduled from inside a task callback ran one tick early
+// because current_tick_ was published at the end of the heartbeat instead of the start.
 TEST_F(SchedulerTest, RunTaskLaterFromCallback)
 {
     bool executed = false;
@@ -227,6 +179,37 @@ TEST_F(SchedulerTest, CancelTasksKeepsInternalTasks)
     EXPECT_FALSE(plugin_executed);
 }
 
+// Regression test for #436: a cancelled task's callback is released by the next heartbeat's
+// main-thread purge (the CraftBukkit pending/temp purge), not kept until its scheduled tick.
+TEST_F(SchedulerTest, CancelTaskReleasesQueuedCallback)
+{
+    auto sentinel = std::make_shared<bool>(false);
+    std::weak_ptr<bool> sentinel_ref = sentinel;
+    bool other_executed = false;
+    auto cancelled = scheduler_->runTaskLater(plugin_, [sentinel]() { *sentinel = true; }, 3);
+    auto kept = scheduler_->runTaskLater(plugin_, [&]() { other_executed = true; }, 3);
+    ASSERT_TRUE(cancelled != nullptr);
+    ASSERT_TRUE(kept != nullptr);
+    sentinel.reset();
+    const auto cancelled_id = cancelled->getTaskId();
+    const auto kept_id = kept->getTaskId();
+    // Drop our task handles: the callback must be released by the scheduler alone.
+    cancelled.reset();
+    kept.reset();
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);  // move both into the scheduled queue
+    scheduler_->cancelTask(cancelled_id);
+    EXPECT_FALSE(sentinel_ref.expired());
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);  // purge drops the cancelled task
+    EXPECT_TRUE(sentinel_ref.expired());
+    EXPECT_TRUE(scheduler_->isQueued(kept_id));
+
+    scheduler_->mainThreadHeartbeat(++tick_count_);
+    EXPECT_TRUE(other_executed);
+    EXPECT_FALSE(scheduler_->isQueued(kept_id));
+}
+
 // Regression test for #351: cancelling an idle async task via cancelTasks() used to re-lock
 // tasks_mtx_ recursively (doCancel() -> removeTask()), throwing "resource deadlock would occur".
 TEST_F(SchedulerTest, CancelAsyncTasksDoesNotDeadlock)
@@ -240,6 +223,8 @@ TEST_F(SchedulerTest, CancelAsyncTasksDoesNotDeadlock)
     EXPECT_FALSE(scheduler_->isQueued(task2->getTaskId()));
 }
 
+// Regression test for #436: cancelling a mid-flight async task lets it finish and reports it
+// running until its worker exits.
 TEST_F(SchedulerTest, CancelRunningAsyncTask)
 {
     std::promise<void> started;
@@ -258,6 +243,7 @@ TEST_F(SchedulerTest, CancelRunningAsyncTask)
     scheduler_->mainThreadHeartbeat(++tick_count_);
     if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
         release.set_value();
+        scheduler_.reset();
         FAIL() << "Async task did not start";
     }
 
@@ -265,87 +251,15 @@ TEST_F(SchedulerTest, CancelRunningAsyncTask)
 
     EXPECT_TRUE(scheduler_->isRunning(task->getTaskId()));
     release.set_value();
-    ASSERT_EQ(finished_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    if (finished_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        scheduler_.reset();
+        FAIL() << "Async task did not finish";
+    }
 
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
     while (scheduler_->isRunning(task->getTaskId()) && std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
-}
-
-TEST_F(SchedulerTest, CancelledAsyncTaskDoesNotStart)
-{
-    const auto thread_count = std::thread::hardware_concurrency();
-    if (thread_count == 0) {
-        GTEST_SKIP() << "No executor threads available";
-    }
-
-    std::atomic<unsigned int> started_count{0};
-    std::atomic<unsigned int> finished_count{0};
-    std::promise<void> all_started;
-    std::promise<void> all_finished;
-    std::promise<void> release;
-    auto all_started_future = all_started.get_future();
-    auto all_finished_future = all_finished.get_future();
-    auto release_future = release.get_future().share();
-    for (unsigned int i = 0; i < thread_count; ++i) {
-        scheduler_->runTaskAsync(plugin_, [&]() {
-            if (started_count.fetch_add(1) + 1 == thread_count) {
-                all_started.set_value();
-            }
-            release_future.wait();
-            if (finished_count.fetch_add(1) + 1 == thread_count) {
-                all_finished.set_value();
-            }
-        });
-    }
-
-    std::atomic<bool> cancelled_task_started{false};
-    scheduler_->runTaskAsync(plugin_, [&]() { cancelled_task_started = true; });
-    scheduler_->mainThreadHeartbeat(++tick_count_);
-    if (all_started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
-        release.set_value();
-        FAIL() << "Executor workers did not start";
-    }
-
-    scheduler_->cancelTasks(plugin_);
-    release.set_value();
-    ASSERT_EQ(all_finished_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
-    scheduler_->waitForAsyncTasks(plugin_);
-    EXPECT_FALSE(cancelled_task_started);
-}
-
-TEST_F(SchedulerTest, WaitForAsyncTasks)
-{
-    std::promise<void> started;
-    std::promise<void> release;
-    std::promise<void> allow_release;
-    auto started_future = started.get_future();
-    auto release_future = release.get_future().share();
-    auto allow_release_future = allow_release.get_future();
-    auto task = scheduler_->runTaskAsync(plugin_, [&]() {
-        started.set_value();
-        release_future.wait();
-    });
-    ASSERT_TRUE(task != nullptr);
-
-    scheduler_->mainThreadHeartbeat(++tick_count_);
-    if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
-        release.set_value();
-        FAIL() << "Async task did not start";
-    }
-
-    scheduler_->cancelTasks(plugin_);
-    EXPECT_TRUE(scheduler_->isRunning(task->getTaskId()));
-    std::jthread releaser([&]() {
-        allow_release_future.wait();
-        release.set_value();
-    });
-
-    allow_release.set_value();
-    scheduler_->waitForAsyncTasks(plugin_);
-
     EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
 }
 
@@ -363,6 +277,7 @@ TEST_F(SchedulerTest, TaskIsRunning)
     EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
 }
 
+// Regression test for #436: isRunning() was inverted for async tasks (true while idle).
 TEST_F(SchedulerTest, AsyncTaskIsRunning)
 {
     std::promise<void> started;
@@ -382,15 +297,19 @@ TEST_F(SchedulerTest, AsyncTaskIsRunning)
 
     if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
         release.set_value();
+        scheduler_.reset();
         FAIL() << "Async task did not start";
     }
     EXPECT_TRUE(scheduler_->isRunning(task->getTaskId()));
     release.set_value();
-    ASSERT_EQ(finished_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    if (finished_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        scheduler_.reset();
+        FAIL() << "Async task did not finish";
+    }
 
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
     while (scheduler_->isRunning(task->getTaskId()) && std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     EXPECT_FALSE(scheduler_->isRunning(task->getTaskId()));
 }

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -180,7 +180,7 @@ TEST_F(SchedulerTest, CancelTasksKeepsInternalTasks)
 }
 
 // Regression test for #436: a cancelled task's callback is released by the next heartbeat's
-// main-thread purge (the CraftBukkit pending/temp purge), not kept until its scheduled tick.
+// main-thread cleanup (the CraftBukkit pending/temp removal), not kept until its scheduled tick.
 TEST_F(SchedulerTest, CancelTaskReleasesQueuedCallback)
 {
     auto sentinel = std::make_shared<bool>(false);
@@ -201,7 +201,7 @@ TEST_F(SchedulerTest, CancelTaskReleasesQueuedCallback)
     scheduler_->cancelTask(cancelled_id);
     EXPECT_FALSE(sentinel_ref.expired());
 
-    scheduler_->mainThreadHeartbeat(++tick_count_);  // purge drops the cancelled task
+    scheduler_->mainThreadHeartbeat(++tick_count_);  // removes the cancelled task
     EXPECT_TRUE(sentinel_ref.expired());
     EXPECT_TRUE(scheduler_->isQueued(kept_id));
 

--- a/tests/test_thread_pool_executor.cpp
+++ b/tests/test_thread_pool_executor.cpp
@@ -37,6 +37,28 @@ TEST(ThreadPoolExecutorTest, ZeroThreads)
     EXPECT_EQ(future.get(), 1);
 }
 
+TEST(ThreadPoolExecutorTest, WaitForTasks)
+{
+    ThreadPoolExecutor executor(1);
+    std::promise<void> started;
+    std::promise<void> release;
+    auto started_future = started.get_future();
+    auto release_future = release.get_future().share();
+    auto future = executor.submit([&]() {
+        started.set_value();
+        release_future.wait();
+    });
+    if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+        release.set_value();
+        FAIL() << "Executor task did not start";
+    }
+
+    std::jthread releaser([&]() { release.set_value(); });
+    executor.wait();
+
+    EXPECT_EQ(future.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+}
+
 // Test if tasks are executed in parallel
 TEST(ThreadPoolExecutorTest, ParallelExecution)
 {

--- a/tests/test_thread_pool_executor.cpp
+++ b/tests/test_thread_pool_executor.cpp
@@ -28,6 +28,15 @@ TEST(ThreadPoolExecutorTest, ExecuteTasks)
     EXPECT_EQ(future2.get(), 5);
 }
 
+TEST(ThreadPoolExecutorTest, ZeroThreads)
+{
+    ThreadPoolExecutor executor(0);
+    auto future = executor.submit([]() { return 1; });
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    EXPECT_EQ(future.get(), 1);
+}
+
 // Test if tasks are executed in parallel
 TEST(ThreadPoolExecutorTest, ParallelExecution)
 {

--- a/tests/test_thread_pool_executor.cpp
+++ b/tests/test_thread_pool_executor.cpp
@@ -37,28 +37,6 @@ TEST(ThreadPoolExecutorTest, ZeroThreads)
     EXPECT_EQ(future.get(), 1);
 }
 
-TEST(ThreadPoolExecutorTest, WaitForTasks)
-{
-    ThreadPoolExecutor executor(1);
-    std::promise<void> started;
-    std::promise<void> release;
-    auto started_future = started.get_future();
-    auto release_future = release.get_future().share();
-    auto future = executor.submit([&]() {
-        started.set_value();
-        release_future.wait();
-    });
-    if (started_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
-        release.set_value();
-        FAIL() << "Executor task did not start";
-    }
-
-    std::jthread releaser([&]() { release.set_value(); });
-    executor.wait();
-
-    EXPECT_EQ(future.wait_for(std::chrono::seconds(0)), std::future_status::ready);
-}
-
 // Test if tasks are executed in parallel
 TEST(ThreadPoolExecutorTest, ParallelExecution)
 {


### PR DESCRIPTION
Improves async scheduler task lifetime safety during plugin cancellation and reload.

- Prevents queued and running async callbacks from outliving C++ plugins
- Waits for async work to finish before unloading plugin libraries
- Fixes async task cancellation, exception cleanup, and running-state reporting
- Makes internal task scheduling safe across BDS worker threads
- Handles executor enqueue failures without leaving pending task counts stuck
- Adds regression tests for async cancellation and cross-thread scheduling

Follow-up to #351.