### PR TITLE
Include the endstone package in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ extra-arguments = [
 [tool.conan-py-build.wheel]
 packages = ["endstone"]
 
+[tool.conan-py-build.sdist]
+include = ["endstone"]
+
 [tool.conan-py-build.version]
 provider = "setuptools_scm"
 


### PR DESCRIPTION
Hi!

The sdist was not including the endstone package, the backend's sdist defaults assume `src/<name>`, but endstone's Python package lives at the repo root, so it has to be included explicitly.
