### PR TITLE
feat(event): add swim event and dispatch sprint/sneak via PlayerActionPacket

### DIFF
--- a/endstone/event/__init__.py
+++ b/endstone/event/__init__.py
@@ -118,6 +118,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "PlayerSkinChangeEvent",
             "PlayerSneakEvent",
             "PlayerSprintEvent",
+            "PlayerSwimEvent",
             "PlayerTeleportEvent",
             "PluginDisableEvent",
             "PluginEnableEvent",

--- a/endstone/event/__init__.pyi
+++ b/endstone/event/__init__.pyi
@@ -78,6 +78,7 @@ __all__ = [
     "PlayerSkinChangeEvent",
     "PlayerSneakEvent",
     "PlayerSprintEvent",
+    "PlayerSwimEvent",
     "PlayerTeleportEvent",
     "PluginDisableEvent",
     "PluginEnableEvent",
@@ -805,6 +806,17 @@ class PlayerSprintEvent(PlayerEvent):
     def is_sprinting(self) -> bool:
         """
         Whether the player is attempting to sprint.
+        """
+        ...
+
+class PlayerSwimEvent(PlayerEvent):
+    """
+    Called when a player starts or stops swimming.
+    """
+    @property
+    def is_swimming(self) -> bool:
+        """
+        Whether the player is swimming.
         """
         ...
 

--- a/include/endstone/endstone.hpp
+++ b/include/endstone/endstone.hpp
@@ -115,6 +115,7 @@ static_assert(_ITERATOR_DEBUG_LEVEL == 0,
 #include "event/player/player_skin_change_event.h"
 #include "event/player/player_sneak_event.h"
 #include "event/player/player_sprint_event.h"
+#include "event/player/player_swim_event.h"
 #include "event/player/player_teleport_event.h"
 #include "event/server/broadcast_message_event.h"
 #include "event/server/map_initialize_event.h"

--- a/include/endstone/event/player/player_swim_event.h
+++ b/include/endstone/event/player/player_swim_event.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "endstone/event/player/player_event.h"
+
+namespace endstone {
+
+/**
+ * @brief Called when a player starts or stops swimming.
+ */
+class PlayerSwimEvent final : public PlayerEvent {
+public:
+    ENDSTONE_EVENT(PlayerSwimEvent)
+
+    explicit PlayerSwimEvent(Player &player, bool swimming) : PlayerEvent(player), swimming_(swimming) {}
+
+    /**
+     * @brief Gets whether the player is swimming.
+     *
+     * @return true when starting to swim, false when stopping
+     */
+    [[nodiscard]] bool isSwimming() const { return swimming_; }
+
+private:
+    bool swimming_;
+};
+
+}  // namespace endstone

--- a/scripts/configs/linux.toml
+++ b/scripts/configs/linux.toml
@@ -685,6 +685,15 @@ extra = 0
 pattern = "55 41 57 41 56 41 55 41 54 53 48 81 EC ? ? ? ? 49 89 FE 48 89 74 24 ? 48 8D 9E"
 
 [[signatures]]
+name = "_ZN20ServerNetworkHandler6handleERK17NetworkIdentifierRK18PlayerActionPacket"
+relative = false
+extra = 0
+# 1. locate PacketHandlerDispatcherInstance<PlayerActionPacket,false>::handle
+# 2. follow its ServerNetworkHandler vtable call at +0x248 to the callback wrapper
+# 3. confirm the wrapper forwards to the PlayerActionPacket action dispatcher
+pattern = "41 57 41 56 53 48 89 D3 49 89 F6 49 89 FF 0F B6 52 10 48 8B 47 F0 49 83 C7 F0"
+
+[[signatures]]
 name = "_ZN20ServerNetworkHandler15tryToLoadPlayerER12ServerPlayerRK17ConnectionRequestRK24PlayerAuthenticationInfo"
 relative = false
 extra = 0

--- a/scripts/configs/windows.toml
+++ b/scripts/configs/windows.toml
@@ -4,20 +4,6 @@ executable = "bedrock_server.exe"
 filename = "bedrock_server"
 
 [[signatures]]
-name = "?handle@ServerNetworkHandler@@UEAAXAEBVNetworkIdentifier@@AEBVPlayerActionPacket@@@Z"
-relative = false
-extra = 0
-# 1. find bytes "63 68 61 74 2E 74 79 70 65 2E 73 6C 65 65 70 69 6E 67 00"
-#    = "chat.type.sleeping\0" (unique); its lone code xref is in the StartSleeping branch of the
-#    PlayerActionPacket action dispatcher
-# 2. follow the code xref to the `chat.type.sleeping` message construction, then walk backward to the
-#    enclosing large switch function's prologue
-# 3. confirm vs the old named DB: the candidate is the ServerNetworkHandler virtual taking
-#    NetworkIdentifier const& and PlayerActionPacket const&; it resolves the sender/sub-client, dispatches
-#    `payload.action`, and contains the Start/StopSleeping cases, not a packet constructor or sibling handler
-pattern = "55 41 57 41 56 41 55 41 54 56 57 53 48 81 EC ? ? ? ? 48 8D AC 24 ? ? ? ? 0F 29 B5 ? ? ? ? 48 C7 85 ? ? ? ? FE FF FF FF 4C 89 C3 49 89 D7 48 89 CE 48 83 C1 F0 45 0F B6 40 10 48 8B 46 F0 48 8B 40 28 FF 15 ? ? ? ? 48 85 C0 0F 84 ? ? ? ? 48 89 C7 48 8D 95 10 01 00 00 48 89 C1 E8 ? ? ? ? 48 8B 85 10 01 00 00 48 3B 43 50 0F 85 ? ? ? ? 8B 43 4C 48 83 F8 22 0F 87"
-
-[[signatures]]
 name = "BlockState::StateListNode::mHead"
 relative = false
 extra = 0
@@ -802,6 +788,17 @@ rip_relative = true
 rip_offset = 1
 
 [[signatures]]
+name = "?initializeServer@ServerInstance@@QEAA_N$$QEAUServerInstanceInitArguments@@@Z"
+relative = false
+extra = 0
+# 1. find bytes "53 65 72 76 65 72 49 6E 73 74 61 6E 63 65 20 54 68 72 65 61 64 00" = "ServerInstance Thread\0"
+#    (unique; prefer this message over the "ServerInstance::initializeServer" label, which byte-matches 5
+#    strings/lambda names and is only unique with its trailing 00)
+# 2. its lone data xref is a `lea` inside this function
+# 3. walk up to the prologue
+pattern = "55 41 57 41 56 41 55 41 54 56 57 53 B8 ? ? ? ? E8 ? ? ? ? 48 29 C4 48 8D AC 24 80 00 00 00 0F 29 B5 ? ? ? ? 48 C7 85 ? ? ? ? FE FF FF FF 48 89 95 ? ? ? ? 48 8D 9A 30 05 00 00"
+
+[[signatures]]
 name = "?_validateLoginPacket@ServerNetworkHandler@@EEAA?AV?$optional@UPlayerAuthenticationInfo@@@std@@AEBVNetworkIdentifier@@AEBVLoginPacket@@@Z"
 relative = false
 extra = 0
@@ -827,15 +824,18 @@ rip_relative = true
 rip_offset = 17
 
 [[signatures]]
-name = "?initializeServer@ServerInstance@@QEAA_N$$QEAUServerInstanceInitArguments@@@Z"
+name = "?handle@ServerNetworkHandler@@UEAAXAEBVNetworkIdentifier@@AEBVPlayerActionPacket@@@Z"
 relative = false
 extra = 0
-# 1. find bytes "53 65 72 76 65 72 49 6E 73 74 61 6E 63 65 20 54 68 72 65 61 64 00" = "ServerInstance Thread\0"
-#    (unique; prefer this message over the "ServerInstance::initializeServer" label, which byte-matches 5
-#    strings/lambda names and is only unique with its trailing 00)
-# 2. its lone data xref is a `lea` inside this function
-# 3. walk up to the prologue
-pattern = "55 41 57 41 56 41 55 41 54 56 57 53 B8 ? ? ? ? E8 ? ? ? ? 48 29 C4 48 8D AC 24 80 00 00 00 0F 29 B5 ? ? ? ? 48 C7 85 ? ? ? ? FE FF FF FF 48 89 95 ? ? ? ? 48 8D 9A 30 05 00 00"
+# 1. find bytes "63 68 61 74 2E 74 79 70 65 2E 73 6C 65 65 70 69 6E 67 00"
+#    = "chat.type.sleeping\0" (unique); its lone code xref is in the StartSleeping branch of the
+#    PlayerActionPacket action dispatcher
+# 2. follow the code xref to the `chat.type.sleeping` message construction, then walk backward to the
+#    enclosing large switch function's prologue
+# 3. confirm vs the old named DB: the candidate is the ServerNetworkHandler virtual taking
+#    NetworkIdentifier const& and PlayerActionPacket const&; it resolves the sender/sub-client, dispatches
+#    `payload.action`, and contains the Start/StopSleeping cases, not a packet constructor or sibling handler
+pattern = "55 41 57 41 56 41 55 41 54 56 57 53 48 81 EC ? ? ? ? 48 8D AC 24 ? ? ? ? 0F 29 B5 ? ? ? ? 48 C7 85 ? ? ? ? FE FF FF FF 4C 89 C3 49 89 D7 48 89 CE 48 83 C1 F0 45 0F B6 40 10 48 8B 46 F0 48 8B 40 28 FF 15 ? ? ? ? 48 85 C0 0F 84 ? ? ? ? 48 89 C7 48 8D 95 10 01 00 00 48 89 C1 E8 ? ? ? ? 48 8B 85 10 01 00 00 48 3B 43 50 0F 85 ? ? ? ? 8B 43 4C 48 83 F8 22 0F 87"
 
 [[signatures]]
 name = "?tryToLoadPlayer@ServerNetworkHandler@@QEAA_NAEAVServerPlayer@@AEBVConnectionRequest@@AEBUPlayerAuthenticationInfo@@@Z"

--- a/scripts/configs/windows.toml
+++ b/scripts/configs/windows.toml
@@ -4,6 +4,20 @@ executable = "bedrock_server.exe"
 filename = "bedrock_server"
 
 [[signatures]]
+name = "?handle@ServerNetworkHandler@@UEAAXAEBVNetworkIdentifier@@AEBVPlayerActionPacket@@@Z"
+relative = false
+extra = 0
+# 1. find bytes "63 68 61 74 2E 74 79 70 65 2E 73 6C 65 65 70 69 6E 67 00"
+#    = "chat.type.sleeping\0" (unique); its lone code xref is in the StartSleeping branch of the
+#    PlayerActionPacket action dispatcher
+# 2. follow the code xref to the `chat.type.sleeping` message construction, then walk backward to the
+#    enclosing large switch function's prologue
+# 3. confirm vs the old named DB: the candidate is the ServerNetworkHandler virtual taking
+#    NetworkIdentifier const& and PlayerActionPacket const&; it resolves the sender/sub-client, dispatches
+#    `payload.action`, and contains the Start/StopSleeping cases, not a packet constructor or sibling handler
+pattern = "55 41 57 41 56 41 55 41 54 56 57 53 48 81 EC ? ? ? ? 48 8D AC 24 ? ? ? ? 0F 29 B5 ? ? ? ? 48 C7 85 ? ? ? ? FE FF FF FF 4C 89 C3 49 89 D7 48 89 CE 48 83 C1 F0 45 0F B6 40 10 48 8B 46 F0 48 8B 40 28 FF 15 ? ? ? ? 48 85 C0 0F 84 ? ? ? ? 48 89 C7 48 8D 95 10 01 00 00 48 89 C1 E8 ? ? ? ? 48 8B 85 10 01 00 00 48 3B 43 50 0F 85 ? ? ? ? 8B 43 4C 48 83 F8 22 0F 87"
+
+[[signatures]]
 name = "BlockState::StateListNode::mHead"
 relative = false
 extra = 0

--- a/src/bedrock/network/server_network_handler.h
+++ b/src/bedrock/network/server_network_handler.h
@@ -45,6 +45,8 @@
 #include "bedrock/world/level/level_interface.h"
 #include "bedrock/world/level/level_listener.h"
 
+class PlayerActionPacket;
+
 class ServerNetworkHandler : public Bedrock::Threading::EnableQueueForMainThread,
                              public NetEventCallback,
                              public LevelListener,
@@ -65,6 +67,7 @@ public:
                                                    Connection::DisconnectFailReason disconnect_reason,
                                                    const std::string &message,
                                                    std::optional<std::string> filtered_message);
+    ENDSTONE_HOOK virtual void handle(const NetworkIdentifier &source, const PlayerActionPacket &packet);
     [[nodiscard]] int getMaxNumPlayers() const;
     int setMaxNumPlayers(int max_players);
     void updateServerAnnouncement();

--- a/src/bedrock/symbols/linux.h
+++ b/src/bedrock/symbols/linux.h
@@ -11,7 +11,7 @@
 
 namespace endstone::runtime {
 
-static constexpr std::array<std::pair<std::string_view, std::size_t>, 66> symbols = {{
+static constexpr std::array<std::pair<std::string_view, std::size_t>, 67> symbols = {{
     {"BlockState::StateListNode::mHead", 234491136},
     {"Enchant::mEnchants", 234331600},
     {"MobEffect::mMobEffects", 234317024},
@@ -112,6 +112,7 @@ static constexpr std::array<std::pair<std::string_view, std::size_t>, 66> symbol
     // ServerInstance
     {"_ZN14ServerInstance16initializeServerEO27ServerInstanceInitArguments", 144647264},
     // ServerNetworkHandler
+    {"_ZN20ServerNetworkHandler6handleERK17NetworkIdentifierRK18PlayerActionPacket", 123703504},
     {"_ZN20ServerNetworkHandler15tryToLoadPlayerER12ServerPlayerRK17ConnectionRequestRK24PlayerAuthenticationInfo", 123686224},
     {"_ZN20ServerNetworkHandler20_validateLoginPacketERK17NetworkIdentifierRK11LoginPacket", 123608848},
     {"_ZN20ServerNetworkHandler24updateServerAnnouncementEv", 123593536},

--- a/src/bedrock/symbols/windows.h
+++ b/src/bedrock/symbols/windows.h
@@ -11,7 +11,7 @@
 
 namespace endstone::runtime {
 
-static constexpr std::array<std::pair<std::string_view, std::size_t>, 66> symbols = {{
+static constexpr std::array<std::pair<std::string_view, std::size_t>, 67> symbols = {{
     {"BlockState::StateListNode::mHead", 199508112},
     {"Enchant::mEnchants", 199688464},
     {"MobEffect::mMobEffects", 199633056},
@@ -113,6 +113,7 @@ static constexpr std::array<std::pair<std::string_view, std::size_t>, 66> symbol
     // ServerNetworkHandler
     {"?_validateLoginPacket@ServerNetworkHandler@@EEAA?AV?$optional@UPlayerAuthenticationInfo@@@std@@AEBVNetworkIdentifier@@AEBVLoginPacket@@@Z", 7645264},
     {"?disconnectClientWithMessage@ServerNetworkHandler@@QEAAXAEBVNetworkIdentifier@@W4SubClientId@@W4DisconnectFailReason@Connection@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$optional@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@7@@Z", 7557648},
+    {"?handle@ServerNetworkHandler@@UEAAXAEBVNetworkIdentifier@@AEBVPlayerActionPacket@@@Z", 7751328},
     {"?tryToLoadPlayer@ServerNetworkHandler@@QEAA_NAEAVServerPlayer@@AEBVConnectionRequest@@AEBUPlayerAuthenticationInfo@@@Z", 7739040},
     {"?updateServerAnnouncement@ServerNetworkHandler@@QEAAXXZ", 7627552},
     // ServerPlayer

--- a/src/endstone/core/player.cpp
+++ b/src/endstone/core/player.cpp
@@ -67,8 +67,6 @@
 #include "endstone/event/player/player_jump_event.h"
 #include "endstone/event/player/player_move_event.h"
 #include "endstone/event/player/player_skin_change_event.h"
-#include "endstone/event/player/player_sneak_event.h"
-#include "endstone/event/player/player_sprint_event.h"
 #include "endstone/form/action_form.h"
 #include "endstone/form/message_form.h"
 
@@ -755,23 +753,6 @@ bool EndstonePlayer::handlePacket(Packet &packet)
     }
     case MinecraftPacketIds::PlayerAuthInputPacket: {
         auto &pk = static_cast<PlayerAuthInputPacket &>(packet);
-        if (pk.getInput(PlayerAuthInputPacket::StartSprinting) && !getHandle().isSprinting()) {
-            PlayerSprintEvent e(*this, true);
-            getServer().getPluginManager().callEvent(e);
-        }
-        if (pk.getInput(PlayerAuthInputPacket::StopSprinting) && getHandle().isSprinting()) {
-            PlayerSprintEvent e(*this, false);
-            getServer().getPluginManager().callEvent(e);
-        }
-        if (pk.getInput(PlayerAuthInputPacket::StartSneaking) && !getHandle().isSneaking()) {
-            PlayerSneakEvent e(*this, true);
-            getServer().getPluginManager().callEvent(e);
-        }
-        if (pk.getInput(PlayerAuthInputPacket::StopSneaking) && getHandle().isSneaking()) {
-            PlayerSneakEvent e(*this, false);
-            getServer().getPluginManager().callEvent(e);
-        }
-
         auto &actions = pk.player_block_actions.actions_;
         for (auto it = actions.begin(); it != actions.end();) {
             const auto &action = *it;

--- a/src/endstone/python/event.cpp
+++ b/src/endstone/python/event.cpp
@@ -352,6 +352,9 @@ void init_event(py::module_ &m, py::class_<Event, PyEvent> &event)
                                                "Called when a player starts or stops sprinting.")
         .def_property_readonly("is_sprinting", &PlayerSprintEvent::isSprinting,
                                "Whether the player is attempting to sprint.");
+    py::class_<PlayerSwimEvent, PlayerEvent>(m, "PlayerSwimEvent", "Called when a player starts or stops swimming.")
+        .def_property_readonly("is_swimming", &PlayerSwimEvent::isSwimming,
+                               "Whether the player is swimming.");
     py::class_<PlayerJoinEvent, PlayerEvent>(m, "PlayerJoinEvent", "Called when a player joins a server.")
         .def_property("join_message", &PlayerJoinEvent::getJoinMessage, &PlayerJoinEvent::setJoinMessage,
                       "The join message to send to all online players.");

--- a/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
+++ b/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
@@ -29,7 +29,9 @@
 #include "endstone/event/player/player_login_event.h"
 #include "endstone/event/player/player_sneak_event.h"
 #include "endstone/event/player/player_sprint_event.h"
+#include "endstone/event/player/player_swim_event.h"
 #include "endstone/runtime/hook.h"
+
 void ServerNetworkHandler::handle(const NetworkIdentifier &source, const PlayerActionPacket &packet)
 {
     const auto &server = endstone::core::EndstoneServer::getInstance();
@@ -54,6 +56,16 @@ void ServerNetworkHandler::handle(const NetworkIdentifier &source, const PlayerA
         }
         case PlayerActionType::StopSneaking: {
             endstone::PlayerSneakEvent event(endstone_player, false);
+            server.getPluginManager().callEvent(event);
+            break;
+        }
+        case PlayerActionType::StartSwimming: {
+            endstone::PlayerSwimEvent event(endstone_player, true);
+            server.getPluginManager().callEvent(event);
+            break;
+        }
+        case PlayerActionType::StopSwimming: {
+            endstone::PlayerSwimEvent event(endstone_player, false);
             server.getPluginManager().callEvent(event);
             break;
         }

--- a/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
+++ b/src/endstone/runtime/bedrock_hooks/server_network_handler.cpp
@@ -18,6 +18,7 @@
 
 #include "bedrock/locale/i18n.h"
 #include "bedrock/network/packet/disconnect_packet.h"
+#include "bedrock/network/packet/player_action_packet.h"
 #include "bedrock/server/server_instance.h"
 #include "endstone/core/entity/components/flag_components.h"
 #include "endstone/core/player.h"
@@ -26,7 +27,43 @@
 #include "endstone/core/util/uuid.h"
 #include "endstone/event/player/player_kick_event.h"
 #include "endstone/event/player/player_login_event.h"
+#include "endstone/event/player/player_sneak_event.h"
+#include "endstone/event/player/player_sprint_event.h"
 #include "endstone/runtime/hook.h"
+void ServerNetworkHandler::handle(const NetworkIdentifier &source, const PlayerActionPacket &packet)
+{
+    const auto &server = endstone::core::EndstoneServer::getInstance();
+    const auto network_handler = server.getServer().getMinecraft()->getServerNetworkHandler();
+    if (auto *player = network_handler->getServerPlayer(source, packet.getSenderSubId())) {
+        auto &endstone_player = player->getEndstoneActor<endstone::core::EndstonePlayer>();
+        switch (packet.payload.action) {
+        case PlayerActionType::StartSprinting: {
+            endstone::PlayerSprintEvent event(endstone_player, true);
+            server.getPluginManager().callEvent(event);
+            break;
+        }
+        case PlayerActionType::StopSprinting: {
+            endstone::PlayerSprintEvent event(endstone_player, false);
+            server.getPluginManager().callEvent(event);
+            break;
+        }
+        case PlayerActionType::StartSneaking: {
+            endstone::PlayerSneakEvent event(endstone_player, true);
+            server.getPluginManager().callEvent(event);
+            break;
+        }
+        case PlayerActionType::StopSneaking: {
+            endstone::PlayerSneakEvent event(endstone_player, false);
+            server.getPluginManager().callEvent(event);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    ENDSTONE_HOOK_CALL_ORIGINAL(&ServerNetworkHandler::handle, this, source, packet);
+}
 
 void ServerNetworkHandler::disconnectClientWithMessage(const NetworkIdentifier &id, const SubClientId sub_id,
                                                        const Connection::DisconnectFailReason reason,


### PR DESCRIPTION
- Add `PlayerSwimEvent`
- Dispatch sprint and sneak events from `PlayerActionPacket` instead of `PlayerAuthInputPacket`.
- Register handler signatures and symbols for PlayerActionPacket on Windows and Linux.

