### PR TITLE
fix: resolve Linux packet compatibility issues for 26.40

### DIFF
--- a/src/bedrock/network/packet/update_soft_enum_packet.h
+++ b/src/bedrock/network/packet/update_soft_enum_packet.h
@@ -25,6 +25,11 @@ enum class SoftEnumUpdateType : uint8_t {
 
 class UpdateSoftEnumPacket : public Packet {
 public:
+#ifdef __linux__
+    // Reserve Packet's tail-padding slot for BDS-compatible field offsets.
+    std::uint32_t packet_tail_padding;
+#endif
+
     SoftEnumUpdateType type;
     std::string enum_name;
     std::vector<std::string> values;

--- a/src/endstone/core/player.cpp
+++ b/src/endstone/core/player.cpp
@@ -16,6 +16,7 @@
 
 #include <RakPeerInterface.h>
 
+#include <cmath>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -776,12 +777,20 @@ bool EndstonePlayer::handlePacket(Packet &packet)
         const auto pos = actor.getPosition();
         const auto rot = actor.getRotation();
         const auto delta = pk.pos - pos;
-        const auto delta_angle = pk.rot - rot;
+
+        // Keep non-finite packet rotations out of movement events.
+        const Vec2 event_rot{
+            std::isfinite(pk.rot.x) ? pk.rot.x : rot.x,
+            std::isfinite(pk.rot.y) ? pk.rot.y : rot.y,
+        };
+        const auto delta_angle = event_rot - rot;
         const auto on_ground = actor.isOnGround();
 
         const Location from = getLocation();
         const auto height_offset = ActorOffset::getHeightOffset(actor.getEntity());
-        const Location to{getDimension(), pk.pos.x, pk.pos.y - height_offset, pk.pos.z, pk.rot.x, pk.rot.y};
+        const Location to{
+            getDimension(), pk.pos.x, pk.pos.y - height_offset, pk.pos.z, event_rot.x, event_rot.y,
+        };
 
         if (pk.getInput(PlayerAuthInputPacket::InputData::Jumping) && on_ground && delta.y > 0.0F) {
             PlayerJumpEvent e{*this, from, to};

--- a/src/endstone/runtime/bedrock_hooks/batched_network_peer.cpp
+++ b/src/endstone/runtime/bedrock_hooks/batched_network_peer.cpp
@@ -94,9 +94,13 @@ void patchPacket(const ClientboundMapItemDataPacket &packet, endstone::core::End
         }
     }
 
+    // Decorations and tracked actor IDs are serialized in parallel.
     pk.payload.decorations.clear();
+    pk.payload.unique_ids.clear();
+
     for (const auto &cursor : render.cursors) {
         if (cursor.isVisible()) {
+            pk.payload.unique_ids.emplace_back(ActorUniqueID::INVALID_ID);
             pk.payload.decorations.emplace_back(
                 std::make_shared<MapDecoration>(static_cast<MapDecoration::Type>(cursor.getType()), cursor.getX(),
                                                 cursor.getY(), cursor.getDirection(), cursor.getCaption(),


### PR DESCRIPTION
## Summary

Fixes three Linux compatibility issues found while testing BDS 1.26.40.8:

- Preserve the BDS-compatible `UpdateSoftEnumPacket` layout on Linux.
- Keep map decorations synchronized with their tracked actor ID entries.
- Prevent non-finite `PlayerAuthInputPacket` rotations from entering movement events.

## Details

### UpdateSoftEnumPacket layout

Clang's Itanium ABI reused the four-byte tail-padding slot of `Packet` for the first derived member, producing a 104-byte layout with incompatible member offsets.

Reserving that slot explicitly restores the expected 112-byte Linux layout.

Validated layout:

- padding: `44`
- type: `48`
- enum name: `56`
- values: `80`
- serialization mode: `104`
- size: `112`

### Map data

Custom map rendering replaced `decorations` without rebuilding the corresponding `unique_ids` array, causing mismatched serialized entries and client disconnects.

The patch clears and rebuilds both arrays together.

### Player auth input

`PlayerAuthInputPacket` may contain non-finite rotation components. Passing those values into `PlayerMoveEvent` caused an unchanged destination to compare as modified, triggering an invalid teleport and rejecting the original movement packet.

The patch uses the actor's current rotation for event processing when a packet rotation component is not finite, while leaving the original packet unchanged for BDS.

## Testing

Tested with:

- BDS `1.26.40.8`
- Endstone `0.11.7.dev76`
- Linux
- Clang/libc++ `20.1.2`

Verified:

- Linux runtime builds successfully
- Repeated player reconnects
- Walking, jumping, sprinting and rapid camera movement
- Custom map packet delivery
- Scoreboard objective add/remove
- `UpdateSoftEnumPacket` decode/encode roundtrip:
  - payload: `29/29` bytes
  - unread bytes: `0`
  - byte-identical output
- No client disconnects, movement rejection or server crashes after applying the fixes