### PR TITLE
Fix {Release=>RelWithDebInfo} in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ pip install -U . -C build-dir=./build
 ### C++ Tests (GTest)
 
 ```bash
-ctest --test-dir build/Release
+ctest --preset conan-relwithdebinfo
 ```
 
 ### Python Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,19 +60,19 @@ Only needed for the manual `cmake --preset` path below; `pip install`-based buil
 **Windows (cmd):**
 
 ```shell
-.\build\Release\generators\conanbuild.bat
+build\RelWithDebInfo\generators\conanbuild.bat
 ```
 
 **Windows (PowerShell):**
 
 ```shell
-.\build\Release\generators\conanbuild.ps1
+build\RelWithDebInfo\generators\conanbuild.ps1
 ```
 
 **Linux:**
 
 ```bash
-source ./build/Release/generators/conanbuild.sh
+source build/RelWithDebInfo/generators/conanbuild.sh
 ```
 
 ## Building
@@ -80,8 +80,8 @@ source ./build/Release/generators/conanbuild.sh
 ### Build with CMake
 
 ```bash
-cmake --preset conan-release
-cmake --build --preset conan-release
+cmake --preset conan-relwithdebinfo
+cmake --build --preset conan-relwithdebinfo
 ```
 
 ### Install from Source (builds Python wheel)


### PR DESCRIPTION
Update `build\{Release=>RelWithDebInfo}\generators` and `conan-{release=>relwithdebinfo}` following recent rename.

Also removed leading `./` from subdirectory paths because they are not needed.