### PR TITLE
Replace `FetchContent_Declare()` with plain `find_package()` for `expected-lite`. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ option(CODE_COVERAGE "Enable code coverage reporting" OFF)
 option(ENDSTONE_ENABLE_DEVTOOLS "Build Endstone with DevTools enabled." OFF)
 option(ENDSTONE_SEPARATE_DEBUG_INFO "Separate debug info into .dbg files on Linux using objcopy" OFF)
 
+find_package(expected-lite REQUIRED)
+
 # Endstone header-only API
 add_subdirectory(include)
 if (NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -3,16 +3,6 @@ project(endstone VERSION 0.11.8 LANGUAGES CXX)
 
 include(FetchContent)
 
-find_package(expected-lite QUIET)
-if (NOT expected-lite_FOUND)
-    FetchContent_Declare(
-            expected-lite
-            GIT_REPOSITORY https://github.com/martinmoene/expected-lite.git
-            GIT_TAG v0.8.0
-    )
-    FetchContent_MakeAvailable(expected-lite)
-endif ()
-
 # A git version (passed by conanfile.py) overrides the project() fallback at build time.
 if (NOT DEFINED ENDSTONE_VERSION_FULL)
     set(ENDSTONE_VERSION_FULL "${PROJECT_VERSION}")


### PR DESCRIPTION
Remove `find_package(... QUIET) / FetchContent_Declare` pattern for `expected-lite` and replace with `find_package(expected-lite REQUIRED)` in top `CMakeLists.txt` file.

In endstone, dependency version info is maintained in `conanfile.py` and as such, using `find_package(... REQUIRED)` in the top file is a recommended practice.