### PR TITLE
feat(plugin): implement load and unload functionality for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `/load`, `/unload`, and `/reload <plugin>` commands to load, unload, and reload individual plugins at runtime without restarting the server. `/load` and `/unload` without arguments load or unload all plugins.
 - Added `Player.send_action_bar()` for sending a message above the player's hotbar.
 - Added `/restart` command (console-only) that gracefully restarts the server without manually relaunching.
 - Added support for custom Python events with optional cancellation.

--- a/endstone/plugin/__init__.pyi
+++ b/endstone/plugin/__init__.pyi
@@ -79,6 +79,16 @@ class PluginLoader:
             plugin: Plugin to disable.
         """
 
+    def unload_plugin(self, plugin: Plugin) -> None:
+        """
+        Unloads the specified plugin.
+
+        Attempting to unload a plugin that is not loaded will have no effect.
+
+        Args:
+            plugin: Plugin to unload.
+        """
+
     @property
     def plugin_file_filters(self) -> list[str]:
         """
@@ -512,6 +522,18 @@ class PluginManager:
     def clear_plugins(self) -> None:
         """
         Disables and removes all plugins.
+        """
+
+    def unload_plugin(self, name: str, force: bool = False) -> bool:
+        """
+        Unloads the plugin with the given name.
+
+        Args:
+            name: Name of the plugin to unload.
+            force: Whether to unload even if another plugin depends on it.
+
+        Returns:
+            `True` if the plugin was unloaded, otherwise `False`.
         """
 
     def call_event(self, event: Event) -> None:

--- a/endstone/plugin/plugin_loader.py
+++ b/endstone/plugin/plugin_loader.py
@@ -165,6 +165,17 @@ class PythonPluginLoader(PluginLoader):
 
         return loaded_plugins
 
+    def unload_plugin(self, plugin: Plugin) -> None:
+        if plugin in self._plugins:
+            self._plugins.remove(plugin)
+
+        prefix = f"endstone_{plugin.name}"
+        for module in list(sys.modules.keys()):
+            if module == prefix or module.startswith(prefix + "."):
+                del sys.modules[module]
+
+        importlib.invalidate_caches()
+
     def _load_plugin_from_ep(self, ep: EntryPoint) -> Plugin | None:
         # enforce naming convention
         if ep.dist is None:

--- a/include/endstone/plugin/plugin_loader.h
+++ b/include/endstone/plugin/plugin_loader.h
@@ -145,6 +145,13 @@ public:
     }
 
     /**
+     * Removes the specified plugin, freeing the instance owned by this loader.
+     *
+     * @param plugin Plugin to unload
+     */
+    virtual void unloadPlugin(Plugin &plugin) {}
+
+    /**
      * Retrieves the Server object associated with the PluginLoader.
      *
      * This function returns a reference to the Server object that the PluginLoader is associated with.

--- a/include/endstone/plugin/plugin_manager.h
+++ b/include/endstone/plugin/plugin_manager.h
@@ -143,6 +143,15 @@ public:
     virtual void clearPlugins() = 0;
 
     /**
+     * Disables and removes the specified plugin.
+     *
+     * @param name Name of the plugin to unload
+     * @param force Whether to unload even if other plugins depend on it
+     * @return true if the plugin was unloaded, otherwise false
+     */
+    virtual bool unloadPlugin(const std::string &name, bool force = false) = 0;
+
+    /**
      * Calls an event which will be passed to plugins.
      *
      * @param event Event to be called

--- a/src/endstone/core/CMakeLists.txt
+++ b/src/endstone/core/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(endstone_core
         command/defaults/ban_command.cpp
         command/defaults/ban_ip_command.cpp
         command/defaults/ban_list_command.cpp
+        command/defaults/load_command.cpp
         command/defaults/pardon_command.cpp
         command/defaults/pardon_ip_command.cpp
         command/defaults/plugins_command.cpp
@@ -71,6 +72,7 @@ add_library(endstone_core
         command/defaults/restart_command.cpp
         command/defaults/seed_command.cpp
         command/defaults/status_command.cpp
+        command/defaults/unload_command.cpp
         command/defaults/version_command.cpp
         damage/damage_source.cpp
         enchantments/enchantment.cpp

--- a/src/endstone/core/command/command_map.cpp
+++ b/src/endstone/core/command/command_map.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 #include <format>
 #include <ranges>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -32,6 +33,7 @@
 #include "endstone/core/command/defaults/ban_command.h"
 #include "endstone/core/command/defaults/ban_ip_command.h"
 #include "endstone/core/command/defaults/ban_list_command.h"
+#include "endstone/core/command/defaults/load_command.h"
 #include "endstone/core/command/defaults/pardon_command.h"
 #include "endstone/core/command/defaults/pardon_ip_command.h"
 #include "endstone/core/command/defaults/plugins_command.h"
@@ -39,6 +41,7 @@
 #include "endstone/core/command/defaults/restart_command.h"
 #include "endstone/core/command/defaults/seed_command.h"
 #include "endstone/core/command/defaults/status_command.h"
+#include "endstone/core/command/defaults/unload_command.h"
 #include "endstone/core/command/defaults/version_command.h"
 #include "endstone/core/command/minecraft_command_adapter.h"
 #include "endstone/core/command/minecraft_command_wrapper.h"
@@ -149,6 +152,7 @@ void EndstoneCommandMap::setDefaultCommands()
     registerCommand(std::make_unique<BanCommand>());
     registerCommand(std::make_unique<BanIpCommand>());
     registerCommand(std::make_unique<BanListCommand>());
+    registerCommand(std::make_unique<LoadCommand>());
     registerCommand(std::make_unique<PardonCommand>());
     registerCommand(std::make_unique<PardonIpCommand>());
     registerCommand(std::make_unique<PluginsCommand>());
@@ -156,6 +160,7 @@ void EndstoneCommandMap::setDefaultCommands()
     registerCommand(std::make_unique<RestartCommand>());
     registerCommand(std::make_unique<SeedCommand>());
     registerCommand(std::make_unique<StatusCommand>());
+    registerCommand(std::make_unique<UnloadCommand>());
     registerCommand(std::make_unique<VersionCommand>());
 #ifdef ENDSTONE_WITH_DEVTOOLS
     registerCommand(std::make_unique<DevToolsCommand>());
@@ -164,17 +169,55 @@ void EndstoneCommandMap::setDefaultCommands()
 
 void EndstoneCommandMap::setPluginCommands()
 {
-    const auto plugins = server_.getPluginManager().getPlugins();
+    for (auto *plugin : server_.getPluginManager().getPlugins()) {
+        for (const auto &command : plugin->getDescription().getCommands()) {
+            registerCommand(std::make_unique<PluginCommand>(command, *plugin));
+        }
+    }
+    refreshPluginNames();
+}
+
+void EndstoneCommandMap::registerPluginCommands(Plugin &plugin)
+{
+    for (const auto &command : plugin.getDescription().getCommands()) {
+        registerCommand(std::make_unique<PluginCommand>(command, plugin));
+    }
+    refreshPluginNames();
+}
+
+void EndstoneCommandMap::unregisterPluginCommands(Plugin &plugin)
+{
+    std::lock_guard lock(mutex_);
+
+    std::set<std::string> names;
+    for (const auto &[key, command] : custom_commands_) {
+        if (command->is<PluginCommand>()) {
+            const auto *plugin_command = static_cast<const PluginCommand *>(command.get());
+            if (&plugin_command->getPlugin() == &plugin) {
+                names.emplace(plugin_command->getName());
+            }
+        }
+    }
+
+    for (const auto &name : names) {
+        if (auto it = custom_commands_.find(name); it != custom_commands_.end()) {
+            auto command = it->second;
+            command->unregisterFrom(*this);
+            unregisterCommand(name);
+            std::erase_if(custom_commands_, [&command](const auto &entry) { return entry.second == command; });
+        }
+    }
+
+    refreshPluginNames();
+}
+
+void EndstoneCommandMap::refreshPluginNames()
+{
     std::vector<std::string> plugin_names;
-    for (auto *plugin : plugins) {
+    for (const auto *plugin : server_.getPluginManager().getPlugins()) {
         auto name = plugin->getName();
         std::ranges::transform(name, name.begin(), [](unsigned char c) { return std::tolower(c); });
         plugin_names.emplace_back(name);
-
-        auto commands = plugin->getDescription().getCommands();
-        for (const auto &command : commands) {
-            registerCommand(std::make_unique<PluginCommand>(command, *plugin));
-        }
     }
     clearEnumValues("PluginName");
     getHandle().getRegistry().addEnumValues("PluginName", plugin_names);

--- a/src/endstone/core/command/command_map.h
+++ b/src/endstone/core/command/command_map.h
@@ -21,6 +21,10 @@
 #include "endstone/command/command.h"
 #include "endstone/command/command_map.h"
 
+namespace endstone {
+class Plugin;
+}
+
 namespace endstone::core {
 
 class EndstoneServer;
@@ -32,11 +36,14 @@ public:
     void clearCommands() override;
     [[nodiscard]] std::shared_ptr<Command> getCommand(std::string name) const override;
     [[nodiscard]] ::MinecraftCommands &getHandle() const;
+    void registerPluginCommands(Plugin &plugin);
+    void unregisterPluginCommands(Plugin &plugin);
 
 private:
     friend class EndstoneServer;
     void setDefaultCommands();
     void setPluginCommands();
+    void refreshPluginNames();
     void unregisterCommand(std::string name);
     void clearEnumValues(const std::string &enum_name);
     void removeEnumValueFromExisting(const std::string &enum_name, const std::string &enum_value);

--- a/src/endstone/core/command/defaults/load_command.cpp
+++ b/src/endstone/core/command/defaults/load_command.cpp
@@ -12,22 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "endstone/core/command/defaults/reload_command.h"
+#include "endstone/core/command/defaults/load_command.h"
 
-#include "endstone/color_format.h"
+#include <string>
+#include <vector>
+
 #include "endstone/core/server.h"
 
 namespace endstone::core {
 
-ReloadCommand::ReloadCommand() : EndstoneCommand("reload")
+LoadCommand::LoadCommand() : EndstoneCommand("load")
 {
-    setDescription("Reloads the server configuration, functions, scripts and plugins.");
-    setUsages("/reload", "/reload [plugin: str]");
-    setPermissions("endstone.command.reload");
-    setAliases("rl");
+    setDescription("Loads a plugin.");
+    setUsages("/load", "/load <plugin: str>");
+    setPermissions("endstone.command.load");
 }
 
-bool ReloadCommand::execute(const NotNull<CommandSender> &sender, const std::vector<std::string> &args) const
+bool LoadCommand::execute(const NotNull<CommandSender> &sender, const std::vector<std::string> &args) const
 {
     if (!testPermission(sender)) {
         return true;
@@ -35,16 +36,17 @@ bool ReloadCommand::execute(const NotNull<CommandSender> &sender, const std::vec
 
     auto &server = EndstoneServer::getInstance();
     if (args.empty()) {
-        server.reload();
-        server.broadcast(ColorFormat::Green + "Reload complete.", Server::BroadcastChannelAdmin);
-    }
-    else if (!server.reloadPlugin(args[0])) {
-        sender->sendErrorMessage("Failed to reload plugin '{}'.", args[0]);
+        server.loadAllPlugins();
+        sender->sendMessage("All plugins loaded.");
         return true;
     }
-    else {
-        sender->sendMessage("Plugin '{}' reloaded.", args[0]);
+
+    if (!server.loadPlugin(args[0])) {
+        sender->sendErrorMessage("Failed to load plugin '{}'.", args[0]);
+        return true;
     }
+
+    sender->sendMessage("Plugin '{}' loaded.", args[0]);
     return true;
 }
 

--- a/src/endstone/core/command/defaults/load_command.cpp
+++ b/src/endstone/core/command/defaults/load_command.cpp
@@ -36,6 +36,7 @@ bool LoadCommand::execute(const NotNull<CommandSender> &sender, const std::vecto
 
     auto &server = EndstoneServer::getInstance();
     if (args.empty()) {
+        server.unloadAllPlugins();
         server.loadAllPlugins();
         sender->sendMessage("All plugins loaded.");
         return true;

--- a/src/endstone/core/command/defaults/load_command.h
+++ b/src/endstone/core/command/defaults/load_command.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,24 +14,14 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "endstone/plugin/plugin_loader.h"
+#include "endstone/core/command/endstone_command.h"
 
 namespace endstone::core {
 
-class CppPluginLoader : public PluginLoader {
+class LoadCommand : public EndstoneCommand {
 public:
-    explicit CppPluginLoader(Server &server);
-    [[nodiscard]] Plugin *loadPlugin(std::string file) override;
-    [[nodiscard]] std::vector<std::string> getPluginFileFilters() const override;
-    void unloadPlugin(Plugin &plugin) override;
-
-private:
-    std::filesystem::path prefix_;
-    std::vector<std::unique_ptr<Plugin, std::function<void(Plugin *)>>> plugins_;
+    LoadCommand();
+    bool execute(const NotNull<CommandSender> &sender, const std::vector<std::string> &args) const override;
 };
 
 }  // namespace endstone::core

--- a/src/endstone/core/command/defaults/unload_command.cpp
+++ b/src/endstone/core/command/defaults/unload_command.cpp
@@ -12,22 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "endstone/core/command/defaults/reload_command.h"
+#include "endstone/core/command/defaults/unload_command.h"
 
-#include "endstone/color_format.h"
+#include <string>
+#include <vector>
+
 #include "endstone/core/server.h"
 
 namespace endstone::core {
 
-ReloadCommand::ReloadCommand() : EndstoneCommand("reload")
+UnloadCommand::UnloadCommand() : EndstoneCommand("unload")
 {
-    setDescription("Reloads the server configuration, functions, scripts and plugins.");
-    setUsages("/reload", "/reload [plugin: str]");
-    setPermissions("endstone.command.reload");
-    setAliases("rl");
+    setDescription("Unloads a plugin.");
+    setUsages("/unload", "/unload <plugin: str>");
+    setPermissions("endstone.command.unload");
 }
 
-bool ReloadCommand::execute(const NotNull<CommandSender> &sender, const std::vector<std::string> &args) const
+bool UnloadCommand::execute(const NotNull<CommandSender> &sender, const std::vector<std::string> &args) const
 {
     if (!testPermission(sender)) {
         return true;
@@ -35,16 +36,17 @@ bool ReloadCommand::execute(const NotNull<CommandSender> &sender, const std::vec
 
     auto &server = EndstoneServer::getInstance();
     if (args.empty()) {
-        server.reload();
-        server.broadcast(ColorFormat::Green + "Reload complete.", Server::BroadcastChannelAdmin);
-    }
-    else if (!server.reloadPlugin(args[0])) {
-        sender->sendErrorMessage("Failed to reload plugin '{}'.", args[0]);
+        server.unloadAllPlugins();
+        sender->sendMessage("All plugins unloaded.");
         return true;
     }
-    else {
-        sender->sendMessage("Plugin '{}' reloaded.", args[0]);
+
+    if (!server.unloadPlugin(args[0])) {
+        sender->sendErrorMessage("Failed to unload plugin '{}'.", args[0]);
+        return true;
     }
+
+    sender->sendMessage("Plugin '{}' unloaded.", args[0]);
     return true;
 }
 

--- a/src/endstone/core/command/defaults/unload_command.h
+++ b/src/endstone/core/command/defaults/unload_command.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,24 +14,14 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "endstone/plugin/plugin_loader.h"
+#include "endstone/core/command/endstone_command.h"
 
 namespace endstone::core {
 
-class CppPluginLoader : public PluginLoader {
+class UnloadCommand : public EndstoneCommand {
 public:
-    explicit CppPluginLoader(Server &server);
-    [[nodiscard]] Plugin *loadPlugin(std::string file) override;
-    [[nodiscard]] std::vector<std::string> getPluginFileFilters() const override;
-    void unloadPlugin(Plugin &plugin) override;
-
-private:
-    std::filesystem::path prefix_;
-    std::vector<std::unique_ptr<Plugin, std::function<void(Plugin *)>>> plugins_;
+    UnloadCommand();
+    bool execute(const NotNull<CommandSender> &sender, const std::vector<std::string> &args) const override;
 };
 
 }  // namespace endstone::core

--- a/src/endstone/core/plugin/cpp_plugin_loader.cpp
+++ b/src/endstone/core/plugin/cpp_plugin_loader.cpp
@@ -118,6 +118,8 @@ Plugin *CppPluginLoader::loadPlugin(std::string file)
                      "API version: {}, but the server has an incompatible API version: {}.",
                      plugin->getDescription().getName(), plugin->getDescription().getAPIVersion(),
                      supported_api_version);
+        delete plugin;
+        CLOSE_LIBRARY(module);
         return nullptr;
     }
 

--- a/src/endstone/core/plugin/cpp_plugin_loader.cpp
+++ b/src/endstone/core/plugin/cpp_plugin_loader.cpp
@@ -139,6 +139,16 @@ std::vector<std::string> CppPluginLoader::getPluginFileFilters() const
 #endif
 }
 
+void CppPluginLoader::unloadPlugin(Plugin &plugin)
+{
+    for (auto it = plugins_.begin(); it != plugins_.end(); ++it) {
+        if (it->get() == &plugin) {
+            plugins_.erase(it);
+            return;
+        }
+    }
+}
+
 }  // namespace endstone::core
 
 #undef LOAD_LIBRARY

--- a/src/endstone/core/plugin/plugin_manager.cpp
+++ b/src/endstone/core/plugin/plugin_manager.cpp
@@ -507,6 +507,55 @@ void EndstonePluginManager::clearPlugins()
     default_perms_[PermissionLevel::Console].clear();
 }
 
+bool EndstonePluginManager::unloadPlugin(const std::string &name, bool force)
+{
+    auto *plugin = getPlugin(name);
+    if (!plugin) {
+        return false;
+    }
+
+    if (!force) {
+        const auto &provides = plugin->getDescription().getProvides();
+        for (const auto *other : plugins_) {
+            if (other == plugin) {
+                continue;
+            }
+            for (const auto &depend : other->getDescription().getDepend()) {
+                if (depend == plugin->getName() || std::ranges::find(provides, depend) != provides.end()) {
+                    server_.getLogger().error("Cannot unload plugin '{}': it is required by '{}'.", name,
+                                              other->getName());
+                    return false;
+                }
+            }
+        }
+    }
+
+    disablePlugin(*plugin);
+    std::erase(plugins_, plugin);
+    std::erase_if(lookup_names_, [plugin](const auto &entry) { return entry.second == plugin; });
+    removePluginPermissions(*plugin);
+    plugin->getPluginLoader().unloadPlugin(*plugin);
+    return true;
+}
+
+void EndstonePluginManager::removePluginPermissions(Plugin &plugin)
+{
+    for (const auto &perm : plugin.getDescription().getPermissions()) {
+        auto name = perm.getName();
+        std::ranges::transform(name, name.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (const auto it = permissions_.find(name); it != permissions_.end()) {
+            auto *ptr = it->second.get();
+            default_perms_[PermissionLevel::Default].get<1>().erase(ptr);
+            default_perms_[PermissionLevel::Operator].get<1>().erase(ptr);
+            default_perms_[PermissionLevel::Console].get<1>().erase(ptr);
+            permissions_.erase(it);
+        }
+    }
+    dirtyPermissibles(PermissionLevel::Default);
+    dirtyPermissibles(PermissionLevel::Operator);
+    dirtyPermissibles(PermissionLevel::Console);
+}
+
 void EndstonePluginManager::callEvent(Event &event)
 {
     if (event.isAsynchronous() && server_.isPrimaryThread()) {

--- a/src/endstone/core/plugin/plugin_manager.h
+++ b/src/endstone/core/plugin/plugin_manager.h
@@ -56,6 +56,7 @@ public:
     void disablePlugin(Plugin &plugin) override;
     void disablePlugins() override;
     void clearPlugins() override;
+    bool unloadPlugin(const std::string &name, bool force = false) override;
 
     /** Event system */
     void callEvent(Event &event) override;
@@ -105,6 +106,7 @@ private:
     void initPlugin(Plugin &plugin, PluginLoader &loader, const std::filesystem::path &base_folder);
     void calculatePermissionDefault(Permission &perm);
     void dirtyPermissibles(PermissionLevel level) const;
+    void removePluginPermissions(Plugin &plugin);
     [[nodiscard]] PluginLoader *resolvePluginLoader(const std::string &file) const;
     Server &server_;
     std::vector<std::unique_ptr<PluginLoader>> plugin_loaders_;

--- a/src/endstone/core/plugin/python_plugin_loader.cpp
+++ b/src/endstone/core/plugin/python_plugin_loader.cpp
@@ -67,6 +67,11 @@ void PythonPluginLoader::disablePlugin(Plugin &plugin) const
     pimpl()->disablePlugin(plugin);
 }
 
+void PythonPluginLoader::unloadPlugin(Plugin &plugin)
+{
+    pimpl()->unloadPlugin(plugin);
+}
+
 PluginLoader *PythonPluginLoader::pimpl() const
 {
     return obj_.cast<PluginLoader *>();

--- a/src/endstone/core/plugin/python_plugin_loader.h
+++ b/src/endstone/core/plugin/python_plugin_loader.h
@@ -32,6 +32,7 @@ public:
     [[nodiscard]] std::vector<std::string> getPluginFileFilters() const override;
     void enablePlugin(Plugin &plugin) const override;
     void disablePlugin(Plugin &plugin) const override;
+    void unloadPlugin(Plugin &plugin) override;
 
 private:
     [[nodiscard]] PluginLoader *pimpl() const;

--- a/src/endstone/core/server.cpp
+++ b/src/endstone/core/server.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <regex>
 #include <sstream>
@@ -132,6 +133,37 @@ std::string readContentKey(const ResourceLocation &location, Logger &logger)
         logger.error("Could not open encryption key file: '{}'. {}.", path, e.what());
         return {};
     }
+}
+
+std::optional<fs::path> resolvePluginFile(const fs::path &plugin_dir, const std::string &name)
+{
+    if (!exists(plugin_dir)) {
+        return std::nullopt;
+    }
+
+    for (const auto &entry : fs::directory_iterator(plugin_dir)) {
+        if (!is_regular_file(entry.status())) {
+            continue;
+        }
+
+        const auto &file = entry.path();
+        auto candidate = file.stem().string();
+        if (file.extension() == ".whl") {
+            candidate = candidate.substr(0, candidate.find('-'));
+            std::ranges::replace(candidate, '-', '_');
+        }
+        else if (file.extension() != ".dll" && file.extension() != ".so") {
+            continue;
+        }
+
+        if (candidate.starts_with("endstone_")) {
+            candidate.erase(0, sizeof("endstone_") - 1);
+        }
+        if (candidate == name) {
+            return file;
+        }
+    }
+    return std::nullopt;
 }
 }  // namespace
 
@@ -438,8 +470,10 @@ bool EndstoneServer::dispatchCommand(const NotNull<CommandSender> &sender, std::
 
 void EndstoneServer::loadPlugins()
 {
-    plugin_manager_->registerLoader(std::make_unique<CppPluginLoader>(*this));
-    plugin_manager_->registerLoader(std::make_unique<PythonPluginLoader>(*this));
+    if (plugin_manager_->plugin_loaders_.empty()) {
+        plugin_manager_->registerLoader(std::make_unique<CppPluginLoader>(*this));
+        plugin_manager_->registerLoader(std::make_unique<PythonPluginLoader>(*this));
+    }
 
     auto plugin_dir = fs::current_path() / "plugins";
 
@@ -483,6 +517,53 @@ void EndstoneServer::enablePlugin(Plugin &plugin)
     plugin_manager_->dirtyPermissibles(PermissionLevel::Operator);
     plugin_manager_->dirtyPermissibles(PermissionLevel::Console);
     plugin_manager_->enablePlugin(plugin);
+}
+
+bool EndstoneServer::loadPlugin(const std::string &name)
+{
+    auto plugin_file = resolvePluginFile(fs::current_path() / "plugins", name);
+    if (!plugin_file) {
+        getLogger().error("Could not find a plugin file for '{}'.", name);
+        return false;
+    }
+
+    auto *plugin = plugin_manager_->loadPlugin(plugin_file->string());
+    if (!plugin) {
+        return false;
+    }
+
+    command_map_->registerPluginCommands(*plugin);
+    enablePlugin(*plugin);
+
+    for (const auto &player : getOnlinePlayers()) {
+        player->updateCommands();
+    }
+    return true;
+}
+
+bool EndstoneServer::unloadPlugin(const std::string &name, bool force)
+{
+    auto *plugin = plugin_manager_->getPlugin(name);
+    if (!plugin) {
+        getLogger().error("Plugin '{}' is not loaded.", name);
+        return false;
+    }
+
+    command_map_->unregisterPluginCommands(*plugin);
+    if (!plugin_manager_->unloadPlugin(name, force)) {
+        command_map_->registerPluginCommands(*plugin);
+        return false;
+    }
+
+    for (const auto &player : getOnlinePlayers()) {
+        player->updateCommands();
+    }
+    return true;
+}
+
+bool EndstoneServer::reloadPlugin(const std::string &name)
+{
+    return unloadPlugin(name) && loadPlugin(name);
 }
 
 void EndstoneServer::disablePlugins() const
@@ -580,6 +661,13 @@ void EndstoneServer::shutdown()
 
 void EndstoneServer::reload()
 {
+    unloadAllPlugins();
+    reloadData();
+    loadAllPlugins();
+}
+
+void EndstoneServer::unloadAllPlugins()
+{
     command_map_->clearCommands();
 
     // Wait for at most 2.5 seconds for plugins to close their async tasks
@@ -598,7 +686,15 @@ void EndstoneServer::reload()
     scheduler.removeCancelledTasks();
 
     plugin_manager_->clearPlugins();
-    reloadData();
+
+    // sync commands
+    for (const auto &player : getOnlinePlayers()) {
+        player->updateCommands();
+    }
+}
+
+void EndstoneServer::loadAllPlugins()
+{
     loadPlugins();
     enablePlugins(PluginLoadOrder::Startup);
     enablePlugins(PluginLoadOrder::PostWorld);

--- a/src/endstone/core/server.h
+++ b/src/endstone/core/server.h
@@ -71,6 +71,11 @@ public:
     void loadPlugins();
     void enablePlugins(PluginLoadOrder type);
     void disablePlugins() const;
+    bool loadPlugin(const std::string &name);
+    bool unloadPlugin(const std::string &name, bool force = false);
+    bool reloadPlugin(const std::string &name);
+    void loadAllPlugins();
+    void unloadAllPlugins();
 
     [[nodiscard]] Scheduler &getScheduler() const override;
     [[nodiscard]] EndstoneScheduler &getEndstoneScheduler() const;

--- a/src/endstone/python/plugin.cpp
+++ b/src/endstone/python/plugin.cpp
@@ -77,6 +77,11 @@ public:
     {
         PYBIND11_OVERRIDE_NAME(void, PluginLoader, "disable_plugin", disablePlugin, std::ref(plugin));
     }
+
+    void unloadPlugin(Plugin &plugin) override
+    {
+        PYBIND11_OVERRIDE_NAME(void, PluginLoader, "unload_plugin", unloadPlugin, std::ref(plugin));
+    }
 };
 
 namespace {
@@ -237,6 +242,14 @@ void init_plugin(py::module &m)
     Args:
         plugin: Plugin to disable.
 )doc")
+        .def("unload_plugin", &PluginLoader::unloadPlugin, py::arg("plugin"), R"doc(
+    Unloads the specified plugin.
+
+    Attempting to unload a plugin that is not loaded will have no effect.
+
+    Args:
+        plugin: Plugin to unload.
+)doc")
         .def_property_readonly("plugin_file_filters", &PluginLoader::getPluginFileFilters,
                                "A list of all filename filters expected by this `PluginLoader`.")
         .def_property_readonly("server", &PluginLoader::getServer, py::return_value_policy::reference,
@@ -328,6 +341,16 @@ void init_plugin(py::module &m)
 )doc")
         .def("disable_plugins", &PluginManager::disablePlugins, "Disables all the loaded plugins.")
         .def("clear_plugins", &PluginManager::clearPlugins, "Disables and removes all plugins.")
+        .def("unload_plugin", &PluginManager::unloadPlugin, py::arg("name"), py::arg("force") = false, R"doc(
+    Unloads the plugin with the given name.
+
+    Args:
+        name: Name of the plugin to unload.
+        force: Whether to unload even if another plugin depends on it.
+
+    Returns:
+        `True` if the plugin was unloaded, otherwise `False`.
+)doc")
         .def("call_event", &PluginManager::callEvent, py::arg("event"), R"doc(
     Calls an event which will be passed to plugins.
 


### PR DESCRIPTION
## Summary

Adds runtime per-plugin load, unload and reload commands, so operators can swap
a single plugin without a full server reload. Works for both C++ and Python plugins.

## Changes

- Added `/load <plugin>` — loads and enables a single plugin by name.
- Added `/unload <plugin>` — disables and unloads a single plugin.
- Added `/reload <plugin>` — reloads a single plugin (unload + load).
- `/load` with no arguments loads all plugins; `/unload` with no arguments unloads all.
- Plugin names resolve against the `plugins/` directory (case-sensitive):
  `.dll`/`.so` files strip the `endstone_` prefix, `.whl` files resolve the distribution name.
- Unloading a plugin that another loaded plugin hard-depends on is refused and
  reported to the sender. The `force` parameter is reserved in the API for future use.
- New permission nodes: `endstone.command.load`, `endstone.command.unload`.
- Refactored `reload()` into reusable `unloadAllPlugins()` / `loadAllPlugins()`.

## API

- `PluginManager::unloadPlugin(const std::string &name, bool force = false)`
- `PluginLoader::unloadPlugin(Plugin &plugin)` (default no-op)

Both are additive and non-breaking.

## Motivation

Lets operators hot-swap a single plugin during development or debugging without
restarting the whole server, and complements the existing full `reload`.

## Testing (not finish yet)

- [x] Built successfully (clang-cl / clang++)
- [x] Manual: `/unload` removes the plugin and its commands; `/load` restores them

<img width="40%" height="40%" alt="image" src="https://github.com/user-attachments/assets/9d04a634-242e-4436-b580-09d50389af0b" />
<img width="40%" height="40%" alt="image" src="https://github.com/user-attachments/assets/70146fac-a3e1-4eb3-ac65-aadb371deb57" />

- [ ] C++ plugin DLL is released on unload and can be reloaded
- [x] Python plugin: `sys.modules` cleared so a reloaded plugin picks up new code
- [ ] Dependency refusal: `/unload B` is rejected while plugin A hard-depends on B
- [x] `reload` (full reload) still works