### PR TITLE
fix: unload incompatible plugins and fix actor death handling

### DIFF
--- a/src/endstone/core/plugin/cpp_plugin_loader.cpp
+++ b/src/endstone/core/plugin/cpp_plugin_loader.cpp
@@ -118,6 +118,8 @@ Plugin *CppPluginLoader::loadPlugin(std::string file)
                      "API version: {}, but the server has an incompatible API version: {}.",
                      plugin->getDescription().getName(), plugin->getDescription().getAPIVersion(),
                      supported_api_version);
+        delete plugin;
+        CLOSE_LIBRARY(module);
         return nullptr;
     }
 

--- a/src/endstone/runtime/bedrock_hooks/script_actor_gameplay_handler.cpp
+++ b/src/endstone/runtime/bedrock_hooks/script_actor_gameplay_handler.cpp
@@ -25,9 +25,9 @@
 #include "endstone/runtime/vtable_hook.h"
 
 namespace {
-bool handleEvent(const ActorKilledEvent &event)
+bool handleEvent(const ActorDiedEvent &event)
 {
-    if (const auto *mob = WeakEntityRef(event.actor_context).tryUnwrap<::Mob>(); mob && !mob->isPlayer()) {
+    if (const auto *mob = event.entity.tryUnwrap<::Mob>(); mob && !mob->isPlayer()) {
         const auto &server = endstone::core::EndstoneServer::getInstance();
         endstone::ActorDeathEvent e{mob->getEndstoneActor<endstone::core::EndstoneMob>(),
                                     std::make_unique<endstone::core::EndstoneDamageSource>(*event.source)};
@@ -78,7 +78,7 @@ HandlerResult ScriptActorGameplayHandler::handleEvent1(const ActorGameplayEvent<
 {
     auto visitor = [&](auto &&arg) -> HandlerResult {
         using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, Details::ValueOrRef<const ActorKilledEvent>> ||
+        if constexpr (std::is_same_v<T, Details::ValueOrRef<const ActorDiedEvent>> ||
                       std::is_same_v<T, Details::ValueOrRef<const ActorRemovedEvent>>) {
             if (!handleEvent(arg.value())) {
                 return HandlerResult::BypassListeners;


### PR DESCRIPTION
Fixed /reload aborting after an incompatible C++ plugin was found. The rejected plugin's module is now destroyed and unloaded before the next plugin scan, so the reload can continue loading compatible plugins.

Fixed ActorDeathEvent potentially not firing.