### PR TITLE
feat(event): add UnknownCommandEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Commands and permissions
 
+- `UnknownCommandEvent` for undefined commands, reporting the `sender`, `command_line` and mutable `message`. Setting `message` to `None` suppresses the unknown-command response.
 - `Server.command_map`, exposing `CommandMap` to Python with `register_command()`, `dispatch()`, `clear_commands()` and `get_command()`.
 - `Command` can now be subclassed in Python to override `execute()`.
 - `/restart` command (console-only) for gracefully restarting the server.

--- a/endstone/event/__init__.py
+++ b/endstone/event/__init__.py
@@ -151,6 +151,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "ServerListPingEvent",
             "ServerLoadEvent",
             "ThunderChangeEvent",
+            "UnknownCommandEvent",
             "WeatherChangeEvent",
             "WeatherEvent",
         ],

--- a/endstone/event/__init__.pyi
+++ b/endstone/event/__init__.pyi
@@ -112,6 +112,7 @@ __all__ = [
     "ServerListPingEvent",
     "ServerLoadEvent",
     "ThunderChangeEvent",
+    "UnknownCommandEvent",
     "WeatherChangeEvent",
     "WeatherEvent",
     "event_handler",
@@ -652,6 +653,31 @@ class ChunkUnloadEvent(ChunkEvent):
     """
     Called when a chunk is unloaded.
     """
+
+class UnknownCommandEvent(Event):
+    """
+    Called when a command sender executes a command that is not defined.
+    """
+    @property
+    def sender(self) -> CommandSender:
+        """
+        The command sender.
+        """
+
+    @property
+    def command_line(self) -> str:
+        """
+        The command that was sent.
+        """
+
+    @property
+    def message(self) -> str | Translatable | None:
+        """
+        The message that will be returned, or `None` if no message will be sent.
+        """
+
+    @message.setter
+    def message(self, arg1: str | Translatable | None) -> None: ...
 
 class PlayerEvent(Event):
     """

--- a/include/endstone/endstone.hpp
+++ b/include/endstone/endstone.hpp
@@ -99,6 +99,7 @@ static_assert(_ITERATOR_DEBUG_LEVEL == 0,
 #include "event/chunk/chunk_event.h"
 #include "event/chunk/chunk_load_event.h"
 #include "event/chunk/chunk_unload_event.h"
+#include "event/command/unknown_command_event.h"
 #include "event/event.h"
 #include "event/event_handler.h"
 #include "event/event_priority.h"

--- a/include/endstone/event/command/unknown_command_event.h
+++ b/include/endstone/event/command/unknown_command_event.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "endstone/command/command_sender.h"
+#include "endstone/event/event.h"
+#include "endstone/message.h"
+
+namespace endstone {
+
+/**
+ * Called when a command sender executes a command that is not defined.
+ */
+class UnknownCommandEvent final : public Event {
+public:
+    ENDSTONE_EVENT(UnknownCommandEvent);
+
+    UnknownCommandEvent(const NotNull<CommandSender> &sender, std::string command_line, std::optional<Message> message)
+        : sender_(sender), command_line_(std::move(command_line)), message_(std::move(message))
+    {
+    }
+
+    /**
+     * Gets the command sender.
+     *
+     * @return sender of the command
+     */
+    [[nodiscard]] const NotNull<CommandSender> &getSender() const { return sender_; }
+
+    /**
+     * Gets the command that was sent.
+     *
+     * @return command sent
+     */
+    [[nodiscard]] std::string getCommandLine() const { return command_line_; }
+
+    /**
+     * Gets the message that will be returned.
+     *
+     * @return unknown command message, or no value if no message will be sent
+     */
+    [[nodiscard]] std::optional<Message> getMessage() const { return message_; }
+
+    /**
+     * Sets the message that will be returned.
+     *
+     * @param message the message to be returned, or no value to avoid sending a message
+     */
+    void setMessage(std::optional<Message> message) { message_ = std::move(message); }
+
+private:
+    NotNull<CommandSender> sender_;
+    std::string command_line_;
+    std::optional<Message> message_;
+};
+
+}  // namespace endstone

--- a/src/endstone/core/command/command_map.cpp
+++ b/src/endstone/core/command/command_map.cpp
@@ -45,6 +45,7 @@
 #include "endstone/core/devtools/devtools_command.h"
 #include "endstone/core/permissions/default_permissions.h"
 #include "endstone/core/server.h"
+#include "endstone/event/command/unknown_command_event.h"
 
 namespace endstone::core {
 
@@ -73,7 +74,11 @@ bool EndstoneCommandMap::dispatch(const NotNull<CommandSender> &sender, std::str
     std::ranges::transform(name, name.begin(), [](unsigned char c) { return std::tolower(c); });
     const auto command = getCommand(name);
     if (!command) {
-        sender->sendErrorMessage(Translatable("commands.generic.unknown", {args[0]}));
+        UnknownCommandEvent event(sender, command_line, Message{Translatable("commands.generic.unknown", {args[0]})});
+        server_.getPluginManager().callEvent(event);
+        if (const auto message = event.getMessage()) {
+            sender->sendErrorMessage(*message);
+        }
         return false;
     }
 

--- a/src/endstone/python/event.cpp
+++ b/src/endstone/python/event.cpp
@@ -262,6 +262,13 @@ void init_event(py::module_ &m, py::class_<Event, PyEvent> &event)
     py::class_<ChunkLoadEvent, ChunkEvent>(m, "ChunkLoadEvent", "Called when a chunk is loaded.");
     py::class_<ChunkUnloadEvent, ChunkEvent>(m, "ChunkUnloadEvent", "Called when a chunk is unloaded.");
 
+    py::class_<UnknownCommandEvent, Event>(m, "UnknownCommandEvent",
+                                           "Called when a command sender executes a command that is not defined.")
+        .def_property_readonly("sender", &UnknownCommandEvent::getSender, "The command sender.")
+        .def_property_readonly("command_line", &UnknownCommandEvent::getCommandLine, "The command that was sent.")
+        .def_property("message", &UnknownCommandEvent::getMessage, &UnknownCommandEvent::setMessage,
+                      "The message that will be returned, or `None` if no message will be sent.");
+
     // Player events
     py::class_<PlayerEvent, Event>(m, "PlayerEvent", "Represents a player related event.")
         .def_property_readonly("player", &PlayerEvent::getPlayer,

--- a/tests/plugin/src/endstone_test/listeners/__init__.py
+++ b/tests/plugin/src/endstone_test/listeners/__init__.py
@@ -1,5 +1,6 @@
 from .actor_event_listener import ActorEventListener
 from .block_event_listener import BlockEventListener
+from .command_event_listener import CommandEventListener
 from .event_listener import EventListener
 from .level_event_listener import LevelEventListener
 from .player_event_listener import PlayerEventListener
@@ -9,6 +10,7 @@ from .weather_event_listener import WeatherEventListener
 __all__ = [
     "ActorEventListener",
     "BlockEventListener",
+    "CommandEventListener",
     "EventListener",
     "LevelEventListener",
     "PlayerEventListener",

--- a/tests/plugin/src/endstone_test/listeners/command_event_listener.py
+++ b/tests/plugin/src/endstone_test/listeners/command_event_listener.py
@@ -1,0 +1,20 @@
+from endstone.event import UnknownCommandEvent, event_handler
+
+from .event_listener import EventListener
+
+
+class CommandEventListener(EventListener):
+    @event_handler
+    def on_unknown_command(self, event: UnknownCommandEvent):
+        if event.command_line == "endstone_test_unknown_command_custom":
+            event.message = "Endstone Test replaced the unknown-command message"
+        elif event.command_line == "endstone_test_unknown_command_silent":
+            event.message = None
+
+        self.record(
+            event,
+            f"{event.sender.name} sent unknown command: {event.command_line}",
+            sender=event.sender.name,
+            command_line=event.command_line,
+            message=None if event.message is None else str(event.message),
+        )

--- a/tests/plugin/src/endstone_test/plugin.py
+++ b/tests/plugin/src/endstone_test/plugin.py
@@ -9,6 +9,7 @@ from endstone_test.command_executor import TestCommandExecutor
 from endstone_test.listeners import (
     ActorEventListener,
     BlockEventListener,
+    CommandEventListener,
     LevelEventListener,
     PlayerEventListener,
     ServerEventListener,
@@ -23,6 +24,7 @@ MARKER_DEFAULT = "not player and not event"
 LISTENERS = (
     ActorEventListener,
     BlockEventListener,
+    CommandEventListener,
     LevelEventListener,
     PlayerEventListener,
     ServerEventListener,

--- a/tests/plugin/src/endstone_test/tests/event/test_command_events.py
+++ b/tests/plugin/src/endstone_test/tests/event/test_command_events.py
@@ -1,0 +1,26 @@
+from endstone_test.recorder import EventRecorder
+
+
+def test_unknown_command(recorder: EventRecorder) -> None:
+    """Verify UnknownCommandEvent reports its sender, command line and message."""
+    snapshots = recorder.require("UnknownCommandEvent")
+    snapshot = next(
+        item
+        for item in snapshots
+        if item["command_line"] == "endstone_test_unknown_command_custom"
+    )
+    assert snapshot["sender"]
+    assert snapshot["message"] == "Endstone Test replaced the unknown-command message"
+
+
+def test_unknown_command_message_can_be_suppressed(
+    recorder: EventRecorder,
+) -> None:
+    """Verify assigning None suppresses the unknown-command message."""
+    snapshots = recorder.require("UnknownCommandEvent")
+    snapshot = next(
+        item
+        for item in snapshots
+        if item["command_line"] == "endstone_test_unknown_command_silent"
+    )
+    assert snapshot["message"] is None

--- a/tests/plugin/src/endstone_test/tests/test_command_map.py
+++ b/tests/plugin/src/endstone_test/tests/test_command_map.py
@@ -1,6 +1,7 @@
 import pytest
 from endstone import Server
-from endstone.command import Command, CommandMap, CommandSender
+from endstone.command import Command, CommandMap, CommandSender, CommandSenderWrapper
+from endstone.lang import Translatable
 
 # =============================================================================
 # Fixtures
@@ -112,8 +113,41 @@ def test_register_with_metadata(command_map: CommandMap) -> None:
 def test_dispatch_an_unknown_command(
     command_map: CommandMap, sender: CommandSender
 ) -> None:
-    """Verify dispatching an unknown command line reports failure."""
-    assert command_map.dispatch(sender, "definitely_not_a_command") is False
+    """Verify an unknown command reports failure with the default message."""
+    errors = []
+    wrapper = CommandSenderWrapper(sender, on_error=errors.append)
+
+    assert command_map.dispatch(wrapper, "definitely_not_a_command value") is False
+    assert len(errors) == 1
+    assert isinstance(errors[0], Translatable)
+    assert errors[0].text == "commands.generic.unknown"
+    assert errors[0].params == ["definitely_not_a_command"]
+
+
+def test_unknown_command_message_can_be_replaced(
+    command_map: CommandMap, sender: CommandSender
+) -> None:
+    """Verify a listener can replace the unknown-command response."""
+    errors = []
+    wrapper = CommandSenderWrapper(sender, on_error=errors.append)
+
+    assert (
+        command_map.dispatch(wrapper, "/endstone_test_unknown_command_custom") is False
+    )
+    assert errors == ["Endstone Test replaced the unknown-command message"]
+
+
+def test_unknown_command_message_can_be_suppressed(
+    command_map: CommandMap, sender: CommandSender
+) -> None:
+    """Verify a listener can suppress the unknown-command response."""
+    errors = []
+    wrapper = CommandSenderWrapper(sender, on_error=errors.append)
+
+    assert (
+        command_map.dispatch(wrapper, "endstone_test_unknown_command_silent") is False
+    )
+    assert errors == []
 
 
 def test_clear_commands_exists(command_map: CommandMap) -> None:


### PR DESCRIPTION
Adds `UnknownCommandEvent`, matching the Paper event for command lines that do not resolve to any registered command.

## Where it fires

`EndstoneCommandMap::dispatch()` removes an optional leading slash, parses the command name and asks the command map to resolve it. When neither a custom Endstone command nor a command in the Bedrock `CommandRegistry` exists, the event is called before the normal unknown-command response is sent.

This stays inside the existing command dispatch path and requires no new Bedrock symbol or hook.

## API

- `sender` — the `CommandSender` that submitted the command.
- `command_line` — the complete command line, without the leading slash.
- `message` — the response that will be sent to the sender.

`message` is writable. A listener can replace the default translatable response with a custom message, or set it to `None` to suppress the response entirely.

The event is not cancellable because the command has already failed resolution and will not execute. Dispatch continues to return `false`, preserving the existing `CommandMap` contract.

## Testing

Adds coverage for:

- the default `commands.generic.unknown` translatable response;
- replacing the response from an event listener;
- suppressing the response by assigning `None`;
- exposing the sender, command line and resulting message through the Python event binding.

GitHub Actions exercises the build, generated stubs and tests on Windows and Linux.