### PR TITLE
feat(command): add a Brigadier-style command tree API

### DIFF
--- a/endstone/command/__init__.py
+++ b/endstone/command/__init__.py
@@ -1,17 +1,32 @@
 import lazy_loader as lazy
 
+from endstone.command._tree import command
+
 __getattr__, __dir__, __all__ = lazy.attach(
     "endstone._python",
     submod_attrs={
         "command": [
+            "ArgumentCommandNode",
+            "ArgumentKind",
+            "ArgumentType",
             "BlockCommandSender",
+            "BuiltinArgumentType",
             "Command",
+            "CommandContext",
+            "CommandError",
             "CommandExecutor",
             "CommandMap",
+            "CommandNode",
             "CommandSender",
             "CommandSenderWrapper",
+            "Commands",
             "ConsoleCommandSender",
+            "LiteralArgumentBuilder",
+            "LiteralCommandNode",
             "ProxiedCommandSender",
+            "RequiredArgumentBuilder",
         ],
     },
 )
+
+__all__ = [*__all__, "arguments", "command"]

--- a/endstone/command/__init__.pyi
+++ b/endstone/command/__init__.pyi
@@ -9,16 +9,28 @@ from endstone import Server
 from endstone.block import Block
 from endstone.lang import Translatable
 from endstone.permissions import Permissible
+from endstone.plugin import Plugin
 
 __all__ = [
+    "ArgumentCommandNode",
+    "ArgumentKind",
+    "ArgumentType",
     "BlockCommandSender",
+    "BuiltinArgumentType",
     "Command",
+    "CommandContext",
+    "CommandError",
     "CommandExecutor",
     "CommandMap",
+    "CommandNode",
     "CommandSender",
     "CommandSenderWrapper",
+    "Commands",
     "ConsoleCommandSender",
+    "LiteralArgumentBuilder",
+    "LiteralCommandNode",
     "ProxiedCommandSender",
+    "RequiredArgumentBuilder",
 ]
 
 class CommandSender(Permissible):
@@ -254,4 +266,267 @@ class CommandExecutor:
 
         Returns:
             `True` if the execution is successful, `False` otherwise.
+        """
+
+class CommandError(Exception): ...
+
+class ArgumentKind:
+    """
+    The built-in argument types Endstone can register with the client.
+    """
+    def __init__(self, value: int) -> None: ...
+
+    __entries = ...
+    @property
+    def name(self) -> str:
+        """
+        name(self: object, /) -> str
+        """
+
+
+    __members__ = ...
+    def __eq__(self, other: object) -> bool: ...
+    def __ne__(self, other: object) -> bool: ...
+    def __getstate__(self, /) -> int: ...
+    def __hash__(self, /) -> int: ...
+    @property
+    def value(self) -> int: ...
+    def __int__(self, /) -> int: ...
+    def __index__(self, /) -> int: ...
+    def __setstate__(self, state: int, /) -> None: ...
+
+    CUSTOM: int = 0
+    BOOLEAN: int = 1
+    INTEGER: int = 2
+    FLOAT: int = 3
+    STRING: int = 4
+    MESSAGE: int = 5
+    RAW_TEXT: int = 6
+    PLAYER: int = 7
+    PLAYERS: int = 8
+    ENTITY: int = 9
+    ENTITIES: int = 10
+    BLOCK_POSITION: int = 11
+    POSITION: int = 12
+    BLOCK_TYPE: int = 13
+    BLOCK_STATES: int = 14
+    ENTITY_TYPE: int = 15
+    JSON: int = 16
+    INTEGER_RANGE: int = 17
+    ENUMERATION: int = 18
+    SOFT_ENUM: int = 19
+
+class ArgumentType:
+    """
+    Describes how a command argument is parsed.
+    """
+    @property
+    def kind(self) -> ArgumentKind:
+        """
+        Which built-in type this is.
+        """
+
+class BuiltinArgumentType(ArgumentType):
+    """
+    An argument type provided by Endstone.
+    """
+
+class CommandNode:
+    """
+    Represents a node in a command tree.
+    """
+    @property
+    def name(self) -> str:
+        """
+        The name of this node.
+        """
+
+    @property
+    def children(self) -> list[CommandNode]:
+        """
+        The children of this node.
+        """
+
+    @property
+    def is_executable(self) -> bool:
+        """
+        Whether a command may end at this node.
+        """
+
+    @property
+    def permissions(self) -> list[str]:
+        """
+        The permissions that allow this branch to be used.
+        """
+
+class LiteralCommandNode(CommandNode):
+    """
+    A node matched by typing a fixed word.
+    """
+    @property
+    def description(self) -> str:
+        """
+        A brief description of this command.
+        """
+
+    @property
+    def aliases(self) -> list[str]:
+        """
+        The alternative names this command is registered under.
+        """
+
+class ArgumentCommandNode(CommandNode):
+    """
+    A node matched by parsing a value.
+    """
+
+class LiteralArgumentBuilder:
+    """
+    Builds a node matched by typing a fixed word.
+    """
+    def description(self, description: str) -> LiteralArgumentBuilder:
+        """
+        Sets a brief description of this command.
+        """
+
+    def aliases(self, aliases: list[str]) -> LiteralArgumentBuilder:
+        """
+        Adds alternative names this command may be typed as.
+        """
+
+    def register_to(self, command_map: CommandMap, owner: Plugin) -> bool:
+        """
+        Registers this command tree.
+
+        Args:
+            command_map: The `CommandMap` to register to.
+            owner: The plugin the command belongs to.
+
+        Returns:
+            `True` on success, `False` if a command with the same name is already registered.
+        """
+
+    @typing.overload
+    def then(self, child: LiteralArgumentBuilder) -> LiteralArgumentBuilder: ...
+    @typing.overload
+    def then(self, child: RequiredArgumentBuilder) -> LiteralArgumentBuilder:
+        """
+        Adds a child branch.
+        """
+
+    def executes(self, handler: collections.abc.Callable) -> LiteralArgumentBuilder:
+        """
+        Sets the handler run when a command ends at this node.
+
+        Returning normally reports the command as successful; raise a `CommandError` to report a
+        failure to the sender.
+        """
+
+    def permission(self, permission: str) -> LiteralArgumentBuilder:
+        """
+        Requires a permission to use this branch.
+
+        A sender holding any one of the permissions added here passes. A sender without one is told
+        they lack permission, and the branch is hidden from their client.
+        """
+
+    def requires(self, predicate: collections.abc.Callable) -> LiteralArgumentBuilder:
+        """
+        Requires a predicate to pass to use this branch.
+
+        Unlike `permission`, a sender that fails is not told why, and the branch is simply absent.
+        Keep the predicate cheap: it runs once per node per parse, and again for every node each time
+        the command tree is sent to a player.
+        """
+
+    def build(self) -> LiteralCommandNode:
+        """
+        Returns the node this builder has shaped.
+        """
+
+class RequiredArgumentBuilder:
+    """
+    Builds a node matched by parsing a value.
+    """
+    @typing.overload
+    def then(self, child: LiteralArgumentBuilder) -> RequiredArgumentBuilder: ...
+    @typing.overload
+    def then(self, child: RequiredArgumentBuilder) -> RequiredArgumentBuilder:
+        """
+        Adds a child branch.
+        """
+
+    def executes(self, handler: collections.abc.Callable) -> RequiredArgumentBuilder:
+        """
+        Sets the handler run when a command ends at this node.
+
+        Returning normally reports the command as successful; raise a `CommandError` to report a
+        failure to the sender.
+        """
+
+    def permission(self, permission: str) -> RequiredArgumentBuilder:
+        """
+        Requires a permission to use this branch.
+
+        A sender holding any one of the permissions added here passes. A sender without one is told
+        they lack permission, and the branch is hidden from their client.
+        """
+
+    def requires(self, predicate: collections.abc.Callable) -> RequiredArgumentBuilder:
+        """
+        Requires a predicate to pass to use this branch.
+
+        Unlike `permission`, a sender that fails is not told why, and the branch is simply absent.
+        Keep the predicate cheap: it runs once per node per parse, and again for every node each time
+        the command tree is sent to a player.
+        """
+
+    def build(self) -> ArgumentCommandNode:
+        """
+        Returns the node this builder has shaped.
+        """
+
+class Commands:
+    """
+    Entry points for building a command tree.
+    """
+    @staticmethod
+    def literal(name: str) -> LiteralArgumentBuilder:
+        """
+        Begins a branch matched by typing a fixed word.
+        """
+
+    @staticmethod
+    def argument(name: str, type: ArgumentType) -> RequiredArgumentBuilder:
+        """
+        Begins a branch matched by parsing a value.
+        """
+
+class CommandContext:
+    """
+    The arguments and sender a command handler is invoked with.
+    """
+    @property
+    def sender(self) -> CommandSender:
+        """
+        The source of this command.
+        """
+
+    @property
+    def command(self) -> Command:
+        """
+        The command being executed.
+        """
+
+    @property
+    def argument_names(self) -> list[str]:
+        """
+        The names of the arguments bound on the branch that ran.
+        """
+
+    def __contains__(self, name: str) -> bool: ...
+    def __getitem__(self, name: str) -> object: ...
+    def get(self, name: str, default: object | None = None) -> object:
+        """
+        Returns the value of the named argument, or the default if it was omitted.
         """

--- a/endstone/command/_tree.py
+++ b/endstone/command/_tree.py
@@ -1,0 +1,217 @@
+import inspect
+import types
+import typing
+from collections.abc import Callable
+
+if typing.TYPE_CHECKING:
+    from endstone._python.command import ArgumentType, Commands
+
+_F = typing.TypeVar("_F", bound=Callable[..., None])
+
+_EMPTY = inspect.Parameter.empty
+
+
+def command(
+    func: _F | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    aliases: list[str] | None = None,
+    permission: str | None = None,
+) -> _F | Callable[[_F], _F]:
+    """Declares a command tree rooted at this method.
+
+    The literal the player types is the method name unless `name` is given. Arguments are the
+    method's own parameters, after `self` and the context - see `subcommand` for the details.
+
+    Args:
+        name: The word the player types. Defaults to the method name.
+        description: A brief description of the command.
+        aliases: Alternative names the command may be typed as.
+        permission: A permission required to use the command.
+    """
+
+    def decorator(f: _F) -> _F:
+        _mark(f, name=name, permission=permission)
+        f._is_command = True
+        f._command_description = description
+        f._command_aliases = list(aliases or [])
+        return f
+
+    return decorator(func) if func is not None else decorator
+
+
+def _mark(f, *, name: str | None, permission: str | None) -> None:
+    f._command_name = name or f.__name__
+    f._command_permission = permission
+    f._command_children = []
+    f.subcommand = _subcommand_factory(f)
+
+
+def _subcommand_factory(parent):
+    def subcommand(
+        func: _F | None = None,
+        *,
+        name: str | None = None,
+        permission: str | None = None,
+    ) -> _F | Callable[[_F], _F]:
+        """Declares a branch under this command.
+
+        The literal is the method name unless `name` is given. Every parameter after `self` and the
+        context becomes an argument: its annotation picks the argument type, and giving it a default
+        makes it optional.
+        """
+
+        def decorator(f: _F) -> _F:
+            _mark(f, name=name, permission=permission)
+            f._is_subcommand = True
+            parent._command_children.append(f)
+            return f
+
+        return decorator(func) if func is not None else decorator
+
+    return subcommand
+
+
+def _unwrap_optional(annotation):
+    """Reduces `X | None` to `X`, leaving anything else alone."""
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        args = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0], True
+    return annotation, False
+
+
+def _spec_for(annotation, parameter_name: str) -> "ArgumentType":
+    """Picks the argument type for a parameter annotation."""
+    from endstone import Player
+    from endstone._python.command import ArgumentType
+    from endstone._python.command import arguments as _arguments
+    from endstone.actor import Actor
+
+    annotation, _ = _unwrap_optional(annotation)
+
+    if typing.get_origin(annotation) is typing.Annotated:
+        for extra in typing.get_args(annotation)[1:]:
+            if isinstance(extra, ArgumentType):
+                return extra
+        annotation, _ = _unwrap_optional(typing.get_args(annotation)[0])
+
+    if isinstance(annotation, ArgumentType):
+        return annotation
+
+    if typing.get_origin(annotation) is list:
+        args = typing.get_args(annotation)
+        item = args[0] if args else None
+        if item is Player:
+            return _arguments.players()
+        if item is Actor:
+            return _arguments.entities()
+        raise TypeError(
+            f"Argument '{parameter_name}' is a list of {item!r}, which has no argument type. "
+            f"Annotate it with one, for example list[Player]."
+        )
+
+    simple = {
+        bool: _arguments.boolean,
+        int: _arguments.integer,
+        float: _arguments.floating,
+        str: _arguments.string,
+        Player: _arguments.player,
+        Actor: _arguments.entity,
+    }
+    if annotation in simple:
+        return simple[annotation]()
+
+    raise TypeError(
+        f"Argument '{parameter_name}' is annotated {annotation!r}, which has no argument type. "
+        f"Use typing.Annotated to give it one, for example "
+        f"Annotated[str, arguments.soft_enum('my_plugin:warps')]."
+    )
+
+
+def _arguments_of(func) -> list[tuple[str, "ArgumentType", bool]]:
+    """Returns (name, type, optional) for every argument parameter of a handler."""
+    signature = inspect.signature(func)
+    try:
+        hints = typing.get_type_hints(func, include_extras=True)
+    except Exception:  # noqa: BLE001 - a bad annotation should name the handler, not explode here
+        hints = {}
+
+    parameters = [p for p in signature.parameters.values() if p.name != "self"]
+    if not parameters:
+        raise TypeError(f"Handler '{func.__qualname__}' must take a CommandContext.")
+
+    result = []
+    for parameter in parameters[1:]:
+        annotation = hints.get(parameter.name, parameter.annotation)
+        if annotation is _EMPTY:
+            raise TypeError(
+                f"Argument '{parameter.name}' of '{func.__qualname__}' needs an annotation to give it an argument type."
+            )
+        _, nullable = _unwrap_optional(annotation)
+        optional = parameter.default is not _EMPTY or nullable
+        result.append((parameter.name, _spec_for(annotation, parameter.name), optional))
+    return result
+
+
+def _handler_for(bound, names: list[str]):
+    def handler(ctx):
+        return bound(ctx, **{name: ctx[name] for name in names if name in ctx})
+
+    return handler
+
+
+def _build(func, holder) -> "Commands":
+    """Builds the branch for one decorated method, and every branch below it."""
+    from endstone._python.command import Commands
+
+    builder = Commands.literal(func._command_name)
+    if func._command_permission:
+        builder = builder.permission(func._command_permission)
+
+    arguments = _arguments_of(func)
+    names = [name for name, _, _ in arguments]
+    bound = getattr(holder, func.__name__)
+
+    mandatory = [i for i, (_, _, optional) in enumerate(arguments) if not optional]
+    last_mandatory = mandatory[-1] if mandatory else -1
+
+    # The chain is built from the tail back, so each argument can be handed the branch that
+    # follows it. Everything from the last mandatory argument onwards can end the command.
+    tail = None
+    for index in range(len(arguments) - 1, -1, -1):
+        name, spec, _ = arguments[index]
+        node = Commands.argument(name, spec)
+        if tail is not None:
+            node = node.then(tail)
+        if index >= last_mandatory:
+            node = node.executes(_handler_for(bound, names))
+        tail = node
+
+    if tail is not None:
+        builder = builder.then(tail)
+    if last_mandatory < 0:
+        builder = builder.executes(_handler_for(bound, names))
+
+    for child in func._command_children:
+        builder = builder.then(_build(child, holder))
+    return builder
+
+
+def build_command_trees(holder: object) -> list["Commands"]:
+    """Returns a builder for every command tree declared on an object with `@command`."""
+    trees = []
+    for attribute in dir(type(holder)):
+        func = getattr(type(holder), attribute, None)
+        if not callable(func) or not getattr(func, "_is_command", False):
+            continue
+
+        builder = _build(func, holder)
+        if func._command_description:
+            builder = builder.description(func._command_description)
+        if func._command_aliases:
+            builder = builder.aliases(func._command_aliases)
+        trees.append(builder)
+    return trees

--- a/endstone/command/arguments.py
+++ b/endstone/command/arguments.py
@@ -1,0 +1,4 @@
+from endstone._python.command import arguments as _arguments
+from endstone._python.command.arguments import *  # noqa: F401,F403
+
+__all__ = [n for n in dir(_arguments) if not n.startswith("_")]

--- a/endstone/plugin/__init__.py
+++ b/endstone/plugin/__init__.py
@@ -53,6 +53,21 @@ class Plugin(_Plugin):
     def _get_description(self) -> PluginDescription:
         return self._description
 
+    def register_commands(self, holder: object | None = None) -> None:
+        """Registers every command tree declared with `@command` on the given object.
+
+        Args:
+            holder (object): The object holding the decorated methods. Defaults to the plugin
+                itself.
+        """
+        if not self.is_enabled:
+            raise RuntimeError(f"Plugin {self.name} attempted to register commands while not enabled")
+
+        from endstone.command._tree import build_command_trees
+
+        for builder in build_command_trees(self if holder is None else holder):
+            builder.register_to(self.server.command_map, self)
+
     def register_events(self, listener: object) -> None:
         """Registers all events defined in the given listener instance.
 

--- a/endstone/plugin/__init__.pyi
+++ b/endstone/plugin/__init__.pyi
@@ -256,6 +256,15 @@ class Plugin:
     default_permission: PermissionDefault | bool | str | None = None
     permissions: dict[str, typing.Any] | None = None
     def __init__(self) -> None: ...
+    def register_commands(self, holder: object | None = None) -> None:
+        """
+        Registers every command tree declared with `@command` on the given object.
+
+        Args:
+            holder (object): The object holding the decorated methods. Defaults to the plugin
+                itself.
+        """
+
     def register_events(self, listener: object) -> None:
         """
         Registers all events defined in the given listener instance.

--- a/include/endstone/command/argument_type.h
+++ b/include/endstone/command/argument_type.h
@@ -1,0 +1,222 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+#include "endstone/util/pointers.h"
+
+namespace endstone {
+
+class CommandSender;
+
+/**
+ * A parsed value for a single command argument.
+ *
+ * The value is type-erased so that Endstone can hand any argument type back to a plugin. Retrieval
+ * is checked against the mangled type name rather than against typeinfo identity, because typeinfo
+ * addresses are not shared between the server and a plugin module.
+ */
+class ArgumentValue {
+public:
+    ArgumentValue() = default;
+
+    /**
+     * Wraps a value of the given type.
+     *
+     * @tparam T Type of the value
+     * @param value Value to wrap
+     * @return An ArgumentValue holding a copy of the value
+     */
+    template <typename T>
+    static ArgumentValue of(T value)
+    {
+        ArgumentValue result;
+        result.type_name_ = typeid(T).name();
+        result.storage_ = std::make_shared<T>(std::move(value));
+        return result;
+    }
+
+    /**
+     * Returns a pointer to the held value if it is of the given type.
+     *
+     * @tparam T Type to retrieve
+     * @return Pointer to the value, or nullptr if this holds nothing or a different type
+     */
+    template <typename T>
+    [[nodiscard]] const T *get() const
+    {
+        if (!storage_ || type_name_ != typeid(T).name()) {
+            return nullptr;
+        }
+        return static_cast<const T *>(storage_.get());
+    }
+
+    /**
+     * Returns whether this holds a value.
+     *
+     * @return true if a value is held, otherwise false
+     */
+    [[nodiscard]] bool hasValue() const { return storage_ != nullptr; }
+
+    /**
+     * Returns the mangled name of the held type, for diagnostics.
+     *
+     * @return Mangled type name, or an empty view if this holds nothing
+     */
+    [[nodiscard]] std::string_view getTypeName() const { return type_name_; }
+
+private:
+    std::string type_name_;
+    std::shared_ptr<const void> storage_;
+};
+
+/**
+ * The built-in argument types Endstone knows how to register with the client.
+ *
+ * An argument type that is not one of these reports Custom and supplies a native type to be
+ * presented to the client in its place.
+ */
+enum class ArgumentKind : std::uint8_t {
+    Custom = 0,
+    Boolean,
+    Integer,
+    Float,
+    String,
+    Message,
+    RawText,
+    Player,
+    Players,
+    Entity,
+    Entities,
+    BlockPosition,
+    Position,
+    BlockType,
+    BlockStates,
+    EntityType,
+    Json,
+    IntegerRange,
+    Enumeration,
+    SoftEnum,
+};
+
+/**
+ * Describes how a command argument is parsed and what the client is told about it.
+ *
+ * Use the Arguments factories for the built-in types. Subclass this to add an argument type of
+ * your own, reporting Custom from getKind() and returning the built-in type it is presented as
+ * from getNativeType().
+ */
+class ArgumentType {
+public:
+    virtual ~ArgumentType() = default;
+
+    /**
+     * Returns which built-in type this is, or Custom for a plugin-provided type.
+     *
+     * @return Kind of this argument type
+     */
+    [[nodiscard]] virtual ArgumentKind getKind() const { return ArgumentKind::Custom; }
+
+    /**
+     * Returns the built-in type this argument is presented to the client as.
+     *
+     * The client only validates and completes types it knows about, so a custom argument borrows
+     * a built-in type's grammar and converts the value server-side.
+     *
+     * @return The type to register with the client
+     */
+    [[nodiscard]] virtual Nullable<ArgumentType> getNativeType() const { return nullptr; }
+
+    /**
+     * Converts a value parsed as the native type into this argument's value.
+     *
+     * Throw a CommandError to reject the input.
+     *
+     * @param native Value parsed as getNativeType()
+     * @param sender Source of the command
+     * @return The converted value
+     */
+    [[nodiscard]] virtual ArgumentValue convert(const ArgumentValue &native, const NotNull<CommandSender> &sender) const
+    {
+        return native;
+    }
+};
+
+/**
+ * An argument type provided by Endstone.
+ *
+ * Created through the Arguments factories rather than directly.
+ */
+class BuiltinArgumentType final : public ArgumentType {
+public:
+    BuiltinArgumentType(ArgumentKind kind, std::string name = {}, std::vector<std::string> values = {})
+        : kind_(kind), name_(std::move(name)), values_(std::move(values))
+    {
+    }
+
+    [[nodiscard]] ArgumentKind getKind() const override { return kind_; }
+
+    /**
+     * Returns the enum or soft enum name, for Enumeration and SoftEnum arguments.
+     *
+     * @return Name of the value set, or an empty string for other kinds
+     */
+    [[nodiscard]] const std::string &getName() const { return name_; }
+
+    /**
+     * Returns the allowed values, for Enumeration arguments.
+     *
+     * @return Allowed values, or an empty list for other kinds
+     */
+    [[nodiscard]] const std::vector<std::string> &getValues() const { return values_; }
+
+    /**
+     * Returns the inclusive lower bound, for Integer and Float arguments.
+     *
+     * @return Minimum accepted value
+     */
+    [[nodiscard]] double getMinimum() const { return minimum_; }
+
+    /**
+     * Returns the inclusive upper bound, for Integer and Float arguments.
+     *
+     * @return Maximum accepted value
+     */
+    [[nodiscard]] double getMaximum() const { return maximum_; }
+
+    BuiltinArgumentType &setRange(double minimum, double maximum)
+    {
+        minimum_ = minimum;
+        maximum_ = maximum;
+        return *this;
+    }
+
+private:
+    ArgumentKind kind_;
+    std::string name_;
+    std::vector<std::string> values_;
+    double minimum_ = -std::numeric_limits<double>::infinity();
+    double maximum_ = std::numeric_limits<double>::infinity();
+};
+
+}  // namespace endstone

--- a/include/endstone/command/arguments.h
+++ b/include/endstone/command/arguments.h
@@ -1,0 +1,138 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "endstone/command/argument_type.h"
+
+namespace endstone {
+
+/**
+ * Factories for the argument types Endstone provides.
+ *
+ * Each one maps onto a grammar the Bedrock client already knows, so parameters keep native
+ * completion and hints as the player types.
+ */
+class Arguments {
+public:
+    /** A boolean, suggested as true or false. */
+    static NotNull<ArgumentType> boolean() { return make(ArgumentKind::Boolean); }
+
+    /** An integer, optionally bounded. */
+    static NotNull<ArgumentType> integer(int minimum = std::numeric_limits<int>::min(),
+                                         int maximum = std::numeric_limits<int>::max())
+    {
+        auto type = std::make_shared<BuiltinArgumentType>(ArgumentKind::Integer);
+        type->setRange(minimum, maximum);
+        return type;
+    }
+
+    /** A floating-point number, optionally bounded. */
+    static NotNull<ArgumentType> floating(float minimum = -std::numeric_limits<float>::infinity(),
+                                          float maximum = std::numeric_limits<float>::infinity())
+    {
+        auto type = std::make_shared<BuiltinArgumentType>(ArgumentKind::Float);
+        type->setRange(minimum, maximum);
+        return type;
+    }
+
+    /** A single word, or a quoted string if it contains spaces. */
+    static NotNull<ArgumentType> string() { return make(ArgumentKind::String); }
+
+    /**
+     * Everything up to the end of the line.
+     *
+     * Must be the last argument on its branch.
+     */
+    static NotNull<ArgumentType> message() { return make(ArgumentKind::Message); }
+
+    /**
+     * Everything up to the end of the line, taken verbatim.
+     *
+     * Unlike message(), selectors in the text are not expanded. Must be the last argument on
+     * its branch.
+     */
+    static NotNull<ArgumentType> rawText() { return make(ArgumentKind::RawText); }
+
+    /** A target selector resolving to exactly one player. */
+    static NotNull<ArgumentType> player() { return make(ArgumentKind::Player); }
+
+    /** A target selector resolving to any number of players. */
+    static NotNull<ArgumentType> players() { return make(ArgumentKind::Players); }
+
+    /** A target selector resolving to exactly one actor. */
+    static NotNull<ArgumentType> entity() { return make(ArgumentKind::Entity); }
+
+    /** A target selector resolving to any number of actors. */
+    static NotNull<ArgumentType> entities() { return make(ArgumentKind::Entities); }
+
+    /** A block position, accepting relative (`~`) and local (`^`) coordinates. */
+    static NotNull<ArgumentType> blockPosition() { return make(ArgumentKind::BlockPosition); }
+
+    /** A precise position, accepting relative (`~`) and local (`^`) coordinates. */
+    static NotNull<ArgumentType> position() { return make(ArgumentKind::Position); }
+
+    /** A block type, completed from the block registry. */
+    static NotNull<ArgumentType> blockType() { return make(ArgumentKind::BlockType); }
+
+    /** A list of block states, such as `["wood_type"="birch"]`. */
+    static NotNull<ArgumentType> blockStates() { return make(ArgumentKind::BlockStates); }
+
+    /** An actor type, completed from the entity registry. */
+    static NotNull<ArgumentType> entityType() { return make(ArgumentKind::EntityType); }
+
+    /** A JSON object. */
+    static NotNull<ArgumentType> json() { return make(ArgumentKind::Json); }
+
+    /** An integer range, such as `3`, `3..`, `..7` or `3..7`. */
+    static NotNull<ArgumentType> integerRange() { return make(ArgumentKind::IntegerRange); }
+
+    /**
+     * One of a fixed set of values.
+     *
+     * The set is validated by the server and is fixed once the command is registered. Use
+     * softEnum() for a set that changes while the server is running.
+     *
+     * @param name Name of the value set, shown to the player when the set is too large to inline
+     * @param values Accepted values
+     */
+    static NotNull<ArgumentType> enumeration(std::string name, std::vector<std::string> values)
+    {
+        return std::make_shared<BuiltinArgumentType>(ArgumentKind::Enumeration, std::move(name), std::move(values));
+    }
+
+    /**
+     * A string completed from a named set of suggestions that can change at runtime.
+     *
+     * Update the set with CommandMap::setSuggestions(). The values are only a hint to the client:
+     * the server accepts any string, so validate the value in your handler.
+     *
+     * @param name Name of the suggestion set
+     */
+    static NotNull<ArgumentType> softEnum(std::string name)
+    {
+        return std::make_shared<BuiltinArgumentType>(ArgumentKind::SoftEnum, std::move(name));
+    }
+
+private:
+    static NotNull<ArgumentType> make(ArgumentKind kind) { return std::make_shared<BuiltinArgumentType>(kind); }
+};
+
+}  // namespace endstone

--- a/include/endstone/command/command_builder.h
+++ b/include/endstone/command/command_builder.h
@@ -1,0 +1,201 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "endstone/command/argument_type.h"
+#include "endstone/command/command_map.h"
+#include "endstone/command/command_node.h"
+#include "endstone/util/pointers.h"
+
+namespace endstone {
+
+class Plugin;
+
+/**
+ * Shared surface for building a node of a command tree.
+ *
+ * A builder is a handle onto the node it is building, so copying one and continuing to chain on
+ * either copy shapes the same node.
+ */
+template <typename Derived, typename NodeType>
+class ArgumentBuilder {
+public:
+    /**
+     * Returns the node this builder has shaped.
+     *
+     * @return The built node
+     */
+    [[nodiscard]] const NotNull<NodeType> &build() const { return node_; }
+
+    // NOLINTNEXTLINE(*-explicit-constructor)
+    operator NotNull<CommandNode>() const { return node_; }
+
+    /**
+     * Adds a child branch.
+     *
+     * @param child Branch to add
+     * @return This builder
+     */
+    Derived then(const NotNull<CommandNode> &child)
+    {
+        node_->addChild(child);
+        return self();
+    }
+
+    /**
+     * Sets the handler run when a command ends at this node.
+     *
+     * Returning normally reports the command as successful; throw a CommandError to report a
+     * failure to the sender.
+     *
+     * @param handler Handler to run
+     * @return This builder
+     */
+    Derived executes(CommandHandler handler)
+    {
+        node_->setHandler(std::move(handler));
+        return self();
+    }
+
+    /**
+     * Requires a permission to use this branch.
+     *
+     * A sender holding any one of the permissions added here passes. A sender without one is told
+     * they lack permission, and the branch is hidden from their client.
+     *
+     * @param permission Permission name
+     * @return This builder
+     */
+    Derived permission(std::string permission)
+    {
+        node_->addPermission(std::move(permission));
+        return self();
+    }
+
+    /**
+     * Requires a predicate to pass to use this branch.
+     *
+     * Unlike permission(), a sender that fails is not told why, and the branch is simply absent.
+     * Keep the predicate cheap: it runs once per node per parse, and again for every node each
+     * time the command tree is sent to a player.
+     *
+     * @param requirement Predicate to test
+     * @return This builder
+     */
+    Derived requires_(CommandRequirement requirement)  // NOLINT(*-identifier-naming)
+    {
+        node_->addRequirement(std::move(requirement));
+        return self();
+    }
+
+protected:
+    explicit ArgumentBuilder(NotNull<NodeType> node) : node_(std::move(node)) {}
+
+    [[nodiscard]] Derived self() const { return static_cast<const Derived &>(*this); }
+
+    NotNull<NodeType> node_;
+};
+
+/**
+ * Builds a node matched by typing a fixed word.
+ */
+class LiteralArgumentBuilder : public ArgumentBuilder<LiteralArgumentBuilder, LiteralCommandNode> {
+public:
+    explicit LiteralArgumentBuilder(std::string name)
+        : ArgumentBuilder(std::make_shared<LiteralCommandNode>(std::move(name)))
+    {
+    }
+
+    /**
+     * Sets a brief description of this command.
+     *
+     * Only meaningful on the root of a command tree.
+     *
+     * @param description New command description
+     * @return This builder
+     */
+    LiteralArgumentBuilder description(std::string description)
+    {
+        node_->setDescription(std::move(description));
+        return *this;
+    }
+
+    /**
+     * Adds alternative names this command may be typed as.
+     *
+     * Only meaningful on the root of a command tree.
+     *
+     * @param aliases Aliases to register
+     * @return This builder
+     */
+    template <typename... Alias>
+    LiteralArgumentBuilder aliases(Alias... aliases)
+    {
+        (node_->addAlias(std::move(aliases)), ...);
+        return *this;
+    }
+
+    /**
+     * Registers this command tree.
+     *
+     * @param command_map the CommandMap to register to
+     * @param owner the plugin the command belongs to
+     * @return true on success, false if a command with the same name is already registered
+     */
+    bool registerTo(CommandMap &command_map, Plugin &owner) const { return command_map.registerCommand(node_, owner); }
+};
+
+/**
+ * Builds a node matched by parsing a value.
+ */
+class RequiredArgumentBuilder : public ArgumentBuilder<RequiredArgumentBuilder, ArgumentCommandNode> {
+public:
+    RequiredArgumentBuilder(std::string name, NotNull<ArgumentType> type)
+        : ArgumentBuilder(std::make_shared<ArgumentCommandNode>(std::move(name), std::move(type)))
+    {
+    }
+};
+
+/**
+ * Entry points for building a command tree.
+ */
+class Commands {
+public:
+    /**
+     * Begins a branch matched by typing a fixed word.
+     *
+     * @param name Word the player types
+     * @return A builder for the new node
+     */
+    static LiteralArgumentBuilder literal(std::string name) { return LiteralArgumentBuilder(std::move(name)); }
+
+    /**
+     * Begins a branch matched by parsing a value.
+     *
+     * @param name Name the value is retrieved by
+     * @param type How the value is parsed
+     * @return A builder for the new node
+     */
+    static RequiredArgumentBuilder argument(std::string name, NotNull<ArgumentType> type)
+    {
+        return {std::move(name), std::move(type)};
+    }
+};
+
+}  // namespace endstone

--- a/include/endstone/command/command_context.h
+++ b/include/endstone/command/command_context.h
@@ -51,13 +51,6 @@ public:
     [[nodiscard]] virtual const Command &getCommand() const = 0;
 
     /**
-     * Returns the command line as it was typed.
-     *
-     * @return Full command line, including the leading slash
-     */
-    [[nodiscard]] virtual std::string getInput() const = 0;
-
-    /**
      * Returns the names of the arguments bound on the branch that ran.
      *
      * @return Bound argument names, in the order they were parsed

--- a/include/endstone/command/command_context.h
+++ b/include/endstone/command/command_context.h
@@ -1,0 +1,134 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <format>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "endstone/command/argument_type.h"
+#include "endstone/command/command_error.h"
+#include "endstone/command/command_sender.h"
+#include "endstone/util/pointers.h"
+
+namespace endstone {
+
+class Command;
+
+/**
+ * The arguments and sender a command handler is invoked with.
+ */
+class CommandContext {
+public:
+    virtual ~CommandContext() = default;
+
+    /**
+     * Returns the source of this command.
+     *
+     * @return Sender that ran the command
+     */
+    [[nodiscard]] virtual const NotNull<CommandSender> &getSender() const = 0;
+
+    /**
+     * Returns the command being executed.
+     *
+     * @return Command which was executed
+     */
+    [[nodiscard]] virtual const Command &getCommand() const = 0;
+
+    /**
+     * Returns the command line as it was typed.
+     *
+     * @return Full command line, including the leading slash
+     */
+    [[nodiscard]] virtual std::string getInput() const = 0;
+
+    /**
+     * Returns the names of the arguments bound on the branch that ran.
+     *
+     * @return Bound argument names, in the order they were parsed
+     */
+    [[nodiscard]] virtual std::vector<std::string> getArgumentNames() const = 0;
+
+    /**
+     * @internal Prefer get() and getOptional().
+     */
+    [[nodiscard]] virtual const ArgumentValue *find(std::string_view name) const = 0;
+
+    /**
+     * Returns whether the named argument was provided on the branch that ran.
+     *
+     * @param name Name the argument was declared with
+     * @return true if the argument has a value, otherwise false
+     */
+    [[nodiscard]] bool has(std::string_view name) const { return find(name) != nullptr; }
+
+    /**
+     * Returns the value of the named argument.
+     *
+     * @tparam T Type the argument was declared to produce
+     * @param name Name the argument was declared with
+     * @return Value of the argument
+     * @throws CommandError if the argument is absent on this branch or is of another type
+     */
+    template <typename T>
+    [[nodiscard]] T get(std::string_view name) const
+    {
+        const auto *value = find(name);
+        if (!value) {
+            throw CommandError(
+                std::format("No argument '{}' on this command. Available: {}.", name, formatArgumentNames()));
+        }
+        const auto *typed = value->get<T>();
+        if (!typed) {
+            throw CommandError(std::format("Argument '{}' is not of the requested type.", name));
+        }
+        return *typed;
+    }
+
+    /**
+     * Returns the value of the named argument, or nothing if it was omitted.
+     *
+     * @tparam T Type the argument was declared to produce
+     * @param name Name the argument was declared with
+     * @return Value of the argument, or std::nullopt if it is absent on this branch
+     * @throws CommandError if the argument is present but of another type
+     */
+    template <typename T>
+    [[nodiscard]] std::optional<T> getOptional(std::string_view name) const
+    {
+        if (!find(name)) {
+            return std::nullopt;
+        }
+        return get<T>(name);
+    }
+
+private:
+    [[nodiscard]] std::string formatArgumentNames() const
+    {
+        std::string result;
+        for (const auto &name : getArgumentNames()) {
+            if (!result.empty()) {
+                result += ", ";
+            }
+            result += name;
+        }
+        return result.empty() ? "none" : result;
+    }
+};
+
+}  // namespace endstone

--- a/include/endstone/command/command_error.h
+++ b/include/endstone/command/command_error.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <exception>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "endstone/message.h"
+
+namespace endstone {
+
+/**
+ * Thrown from a command handler to report a failure to the sender.
+ *
+ * The message is sent to the sender as an error message and the command is reported as
+ * unsuccessful, so it does not count towards a `/execute` success or a command block's
+ * comparator output.
+ */
+class CommandError : public std::exception {
+public:
+    explicit CommandError(Message message) : message_(std::move(message))
+    {
+        if (const auto *text = std::get_if<std::string>(&message_)) {
+            what_ = *text;
+        }
+        else {
+            what_ = std::get<Translatable>(message_).getText();
+        }
+    }
+
+    /**
+     * Returns the message sent to the command sender.
+     *
+     * @return Message to be displayed
+     */
+    [[nodiscard]] const Message &getMessage() const { return message_; }
+
+    [[nodiscard]] const char *what() const noexcept override { return what_.c_str(); }
+
+private:
+    Message message_;
+    std::string what_;
+};
+
+}  // namespace endstone

--- a/include/endstone/command/command_map.h
+++ b/include/endstone/command/command_map.h
@@ -26,6 +26,8 @@
 namespace endstone {
 
 class Command;
+class LiteralCommandNode;
+class Plugin;
 
 /**
  * Represents a command map that manages all commands of the Server.
@@ -83,5 +85,26 @@ public:
      * @return Command with the specified name, a null handle if a command with that label doesn't exist
      */
     [[nodiscard]] virtual Nullable<Command> getCommand(std::string name) const = 0;
+
+    /**
+     * Registers a command tree on behalf of a plugin.
+     *
+     * @param root the root of the command tree, from LiteralArgumentBuilder::build()
+     * @param owner the plugin the command belongs to
+     * @return true on success, false if a command with the same name is already registered
+     */
+    virtual bool registerCommand(NotNull<LiteralCommandNode> root, Plugin &owner) = 0;
+
+    /**
+     * Replaces the values of a named suggestion set.
+     *
+     * The set is what Arguments::softEnum() completes from. Every connected client is updated, so
+     * players see the new values without rejoining. The values are only a hint: the server accepts
+     * any string for a soft enum argument.
+     *
+     * @param name Name of the suggestion set
+     * @param values New values
+     */
+    virtual void setSuggestions(std::string name, std::vector<std::string> values) = 0;
 };
 }  // namespace endstone

--- a/include/endstone/command/command_node.h
+++ b/include/endstone/command/command_node.h
@@ -1,0 +1,238 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <ranges>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "endstone/command/argument_type.h"
+#include "endstone/command/command_context.h"
+#include "endstone/command/command_sender.h"
+#include "endstone/util/pointers.h"
+
+namespace endstone {
+
+/** Invoked when a branch of a command tree is executed. */
+using CommandHandler = std::function<void(const CommandContext &)>;
+
+/** Decides whether a sender may use a branch of a command tree. */
+using CommandRequirement = std::function<bool(const NotNull<CommandSender> &)>;
+
+/** Distinguishes the kinds of node a command tree is built from. */
+enum class CommandNodeType : std::uint8_t {
+    Literal,
+    Argument,
+};
+
+/**
+ * Represents a node in a command tree.
+ */
+class CommandNode {
+public:
+    virtual ~CommandNode() = default;
+
+    /**
+     * Returns which kind of node this is.
+     *
+     * @return Kind of this node
+     */
+    [[nodiscard]] virtual CommandNodeType getType() const = 0;
+
+    /**
+     * Returns the name of this node.
+     *
+     * For a literal this is the word the player types; for an argument it is the name the value is
+     * retrieved by.
+     *
+     * @return Name of this node
+     */
+    [[nodiscard]] const std::string &getName() const { return name_; }
+
+    /**
+     * Returns the children of this node.
+     *
+     * @return Child nodes, in the order they were added
+     */
+    [[nodiscard]] const std::vector<NotNull<CommandNode>> &getChildren() const { return children_; }
+
+    /**
+     * Returns the handler run when a command ends at this node.
+     *
+     * @return Handler, or an empty function if this node is not executable
+     */
+    [[nodiscard]] const CommandHandler &getHandler() const { return handler_; }
+
+    /**
+     * Returns whether a command may end at this node.
+     *
+     * @return true if this node has a handler, otherwise false
+     */
+    [[nodiscard]] bool isExecutable() const { return static_cast<bool>(handler_); }
+
+    /**
+     * Returns the permissions that allow this branch to be used.
+     *
+     * A sender holding any one of them passes. An empty list is open to everyone.
+     *
+     * @return List of permission names
+     */
+    [[nodiscard]] const std::vector<std::string> &getPermissions() const { return permissions_; }
+
+    /**
+     * Returns the predicates that must all pass for this branch to be used.
+     *
+     * @return List of requirements
+     */
+    [[nodiscard]] const std::vector<CommandRequirement> &getRequirements() const { return requirements_; }
+
+    /**
+     * Tests whether a sender may use this node.
+     *
+     * This checks only this node, not its ancestors.
+     *
+     * @param sender Sender to test
+     * @return true if the sender passes this node's permissions and requirements
+     */
+    [[nodiscard]] bool testSilently(const NotNull<CommandSender> &sender) const
+    {
+        if (!permissions_.empty() &&
+            std::none_of(permissions_.begin(), permissions_.end(),
+                         [&sender](const auto &permission) { return sender->hasPermission(permission); })) {
+            return false;
+        }
+        return std::all_of(requirements_.begin(), requirements_.end(),
+                           [&sender](const auto &requirement) { return requirement(sender); });
+    }
+
+    /**
+     * Adds a child to this node.
+     *
+     * If a child with the same name is already present, the two are merged: the incoming node's
+     * children are grafted on, and its handler replaces the existing one if it has one.
+     *
+     * @param child Node to add
+     */
+    void addChild(NotNull<CommandNode> child);
+
+    /** Sets the handler run when a command ends at this node. */
+    void setHandler(CommandHandler handler) { handler_ = std::move(handler); }
+
+    /** Adds a permission that allows this branch to be used. */
+    void addPermission(std::string permission) { permissions_.push_back(std::move(permission)); }
+
+    /** Adds a predicate that must pass for this branch to be used. */
+    void addRequirement(CommandRequirement requirement) { requirements_.push_back(std::move(requirement)); }
+
+protected:
+    explicit CommandNode(std::string name) : name_(std::move(name)) {}
+
+    std::string name_;
+    std::vector<NotNull<CommandNode>> children_;
+    CommandHandler handler_;
+    std::vector<std::string> permissions_;
+    std::vector<CommandRequirement> requirements_;
+};
+
+/**
+ * A node matched by typing a fixed word.
+ */
+class LiteralCommandNode : public CommandNode {
+public:
+    explicit LiteralCommandNode(std::string name) : CommandNode(std::move(name)) {}
+
+    [[nodiscard]] CommandNodeType getType() const override { return CommandNodeType::Literal; }
+
+    /**
+     * Returns a brief description of this command.
+     *
+     * Only meaningful on the root of a command tree.
+     *
+     * @return Description of this command
+     */
+    [[nodiscard]] const std::string &getDescription() const { return description_; }
+
+    /**
+     * Returns the alternative names this command is registered under.
+     *
+     * Only meaningful on the root of a command tree.
+     *
+     * @return List of aliases
+     */
+    [[nodiscard]] const std::vector<std::string> &getAliases() const { return aliases_; }
+
+    /** Sets a brief description of this command. */
+    void setDescription(std::string description) { description_ = std::move(description); }
+
+    /** Adds an alternative name this command is registered under. */
+    void addAlias(std::string alias) { aliases_.push_back(std::move(alias)); }
+
+private:
+    std::string description_;
+    std::vector<std::string> aliases_;
+};
+
+/**
+ * A node matched by parsing a value.
+ */
+class ArgumentCommandNode : public CommandNode {
+public:
+    ArgumentCommandNode(std::string name, NotNull<ArgumentType> type)
+        : CommandNode(std::move(name)), type_(std::move(type))
+    {
+    }
+
+    [[nodiscard]] CommandNodeType getType() const override { return CommandNodeType::Argument; }
+
+    /**
+     * Returns how this argument is parsed.
+     *
+     * @return Type of this argument
+     */
+    [[nodiscard]] const NotNull<ArgumentType> &getArgumentType() const { return type_; }
+
+private:
+    NotNull<ArgumentType> type_;
+};
+
+inline void CommandNode::addChild(NotNull<CommandNode> child)
+{
+    const auto it = std::ranges::find_if(
+        children_, [&child](const auto &existing) { return existing->getName() == child->getName(); });
+    if (it == children_.end()) {
+        children_.push_back(std::move(child));
+        return;
+    }
+
+    auto &existing = *it;
+    if (child->isExecutable()) {
+        existing->setHandler(child->getHandler());
+    }
+    for (const auto &permission : child->getPermissions()) {
+        existing->addPermission(permission);
+    }
+    for (const auto &requirement : child->getRequirements()) {
+        existing->addRequirement(requirement);
+    }
+    for (const auto &grandchild : child->getChildren()) {
+        existing->addChild(grandchild);
+    }
+}
+
+}  // namespace endstone

--- a/scripts/configs/linux.toml
+++ b/scripts/configs/linux.toml
@@ -324,6 +324,35 @@ rip_relative = true
 rip_offset = 1
 
 [[signatures]]
+name = "CommandRegistry::ParseRuleFor<CommandSelector<Actor>>::instance"
+relative = false
+extra = 0
+# 1. unlike Windows, every ParseRuleFor<T>::instance is filled from one combined initializer for
+#    CommandRegistry.cpp, so the three selector rules sit back to back inside it
+# 2. the selector rules carry HardNonTerminal::Selection (0x100008), so `C7 05 ? ? ? ? 08 00 10 00` finds
+#    CommandSelector<Actor> and CommandSelector<Player> and nothing else
+# 3. disambiguate by running on into the next block: Actor is followed by WildcardCommandSelector<Actor>,
+#    whose symbol is WildcardSelection (0x10000a), so the trailing `0A 00 10 00` pins which one matched
+# 4. rip_offset lands on the `mov [rip+X], rax` displacement, which targets the instance itself
+pattern = "48 8D 05 ? ? ? ? 48 89 05 ? ? ? ? 48 C7 05 ? ? ? ? 00 00 00 00 C7 05 ? ? ? ? 08 00 10 00 48 8D 05 ? ? ? ? 48 89 05 ? ? ? ? 48 C7 05 ? ? ? ? 00 00 00 00 C7 05 ? ? ? ? 0A 00 10 00"
+rip_relative = true
+rip_offset = 10
+
+[[signatures]]
+name = "_ZNK19CommandSelectorBase10newResultsERK13CommandOrigin"
+relative = false
+extra = 0
+# 1. this is what actually turns a parsed selector into actors; CommandSelector<T>::results is only a thin
+#    wrapper around it, so one symbol serves both the actor and the player selector
+# 2. the binary is fully stripped, but its own lambdas leave RTTI behind: the type name
+#    "ZNK19CommandSelectorBase10newResultsERK13CommandOriginE3$_0" is the sort-key lambda. Follow that
+#    string to the typeinfo, the typeinfo to the std::__function::__func vtable, and the vtable to the
+#    code that constructs the std::function - that code is inside newResults
+# 3. confirm by shape: ~60 callers (every vanilla command that takes a target) and the same four
+#    MemoryOperators.cpp strings the Windows build shows
+# 4. confirm vs the old named DB
+pattern = "55 41 57 41 56 41 55 41 54 53 48 81 EC ? ? ? ? 49 89 D4 48 89 F3 48 89 FD 48 8B 05"
+[[signatures]]
 name = "_ZN12CommandUtils12getActorNameERK5Actor"
 relative = false
 extra = 0

--- a/scripts/configs/windows.toml
+++ b/scripts/configs/windows.toml
@@ -342,6 +342,37 @@ rip_relative = true
 rip_offset = 1
 
 [[signatures]]
+name = "CommandRegistry::ParseRuleFor<CommandSelector<Actor>>::instance"
+relative = false
+extra = 0
+# 1. the ParseRuleFor<T>::instance globals are each filled by their own tiny dynamic initializer:
+#    `lea rax, parse<T>; mov [rip+X], rax; mov dword [rip+Y], <symbol>; ret`, padded out to 0x20
+# 2. the selector rules all carry HardNonTerminal::Selection (0x100008), so `C7 05 ? ? ? ? 08 00 10 00`
+#    finds CommandSelector<Actor> and CommandSelector<Player> and nothing else - their two initializers
+#    are byte-identical apart from displacements
+# 3. disambiguate by running on into the next initializer: Actor is followed by WildcardCommandSelector
+#    <Actor>, whose symbol is WildcardSelection (0x10000a), so the trailing `0A 00 10 00` pins which of
+#    the two matched
+# 4. rip_offset lands on the `mov [rip+X], rax` displacement, which targets the instance itself
+pattern = "48 8D 05 ? ? ? ? 48 89 05 ? ? ? ? C7 05 ? ? ? ? 08 00 10 00 C3 CC CC CC CC CC CC CC 48 8D 05 ? ? ? ? 48 89 05 ? ? ? ? C7 05 ? ? ? ? 0A 00 10 00 C3"
+rip_relative = true
+rip_offset = 10
+
+[[signatures]]
+name = "?newResults@CommandSelectorBase@@IEBA?AV?$shared_ptr@V?$vector@PEAVActor@@V?$allocator@PEAVActor@@@std@@@std@@@std@@AEBVCommandOrigin@@@Z"
+relative = false
+extra = 0
+# 1. this is what actually turns a parsed selector into actors; CommandSelector<T>::results is only a thin
+#    wrapper that moves the shared_ptr into a CommandSelectorResults, so one symbol serves both the actor
+#    and the player selector
+# 2. it is the sole caller of the two Bedrock::sort_by_cached_key<Actor*> instantiations and of
+#    brstd::shuffle<Actor*>, and has ~60 callers of its own (every vanilla command that takes a target)
+# 3. the prologue below is its own: eight pushes, a 0x208 frame, the rbp bias and the -2 SEH slot, then
+#    the three argument moves. The frame size and the rip displacement are wildcarded so it survives a
+#    patch bump
+# 4. confirm vs the old named DB
+pattern = "55 41 57 41 56 41 55 41 54 56 57 53 48 81 EC ? ? ? ? 48 8D AC 24 ? ? ? ? 48 C7 85 ? ? ? ? FE FF FF FF 4D 89 C6 48 89 D3 48 89 CE 48 8B 0D"
+[[signatures]]
 name = "?symbolToString@CommandRegistry@@AEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@VSymbol@1@@Z"
 relative = false
 extra = 0

--- a/src/bedrock/CMakeLists.txt
+++ b/src/bedrock/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(bedrock STATIC
         resources/resource_pack_stack.cpp
         server/server_instance.cpp
         server/commands/command.cpp
+        server/commands/command_selector.cpp
         server/commands/command_origin.cpp
         server/commands/command_origin_loader.cpp
         server/commands/command_output.cpp

--- a/src/bedrock/server/commands/command.h
+++ b/src/bedrock/server/commands/command.h
@@ -28,14 +28,15 @@ class MinecraftCommandWrapper;
 
 class CommandPosition {
 public:
+    CommandPosition() = default;
     explicit CommandPosition(const Vec3 &);
 
 private:
-    Vec3 offset_;      // +0
-    bool relative_x_;  // +12
-    bool relative_y_;  // +13
-    bool relative_z_;  // +14
-    bool local_;       // +15
+    Vec3 offset_{};          // +0
+    bool relative_x_{true};  // +12
+    bool relative_y_{true};  // +13
+    bool relative_z_{true};  // +14
+    bool local_{false};      // +15
 };
 
 class CommandPositionFloat : public CommandPosition {};

--- a/src/bedrock/server/commands/command_registry.cpp
+++ b/src/bedrock/server/commands/command_registry.cpp
@@ -51,7 +51,7 @@ CommandRegistry::NonTerminal CommandRegistry::findEnum(const std::string &name) 
     if (it == enum_lookup_.end()) {
         return Symbol{0};
     }
-    return Symbol::fromEnumValueIndex(it->second);
+    return Symbol::fromEnumIndex(it->second);
 }
 
 CommandRegistry::Terminal CommandRegistry::findEnumValue(const std::string &name) const

--- a/src/bedrock/server/commands/command_registry.h
+++ b/src/bedrock/server/commands/command_registry.h
@@ -43,6 +43,7 @@ class CommandRunStats;
 
 namespace endstone::core {
 class CommandPermissions;
+class CommandTreeRegistrar;
 class EndstoneCommandMap;
 class EndstonePlayer;
 class MinecraftCommandPermissions;
@@ -218,7 +219,7 @@ public:
         static Symbol fromFactorizationIndex(size_t index);
         static Symbol fromPostfixIndex(size_t index);
         static Symbol fromEnumValueIndex(size_t index) { return {index | EnumValueBit}; }
-        static Symbol fromSoftEnumIndex(size_t index);
+        static Symbol fromSoftEnumIndex(size_t index) { return {index | SoftEnumBit | NonTerminalBit}; }
         static Symbol fromChainedSubcommandIndex(size_t index);
         static Symbol fromChainedSubcommandValueIndex(size_t index);
 
@@ -340,6 +341,7 @@ public:
 
     // Endstone begins
     friend class endstone::core::CommandPermissions;
+    friend class endstone::core::CommandTreeRegistrar;
     friend class endstone::core::EndstoneCommandMap;
     friend class endstone::core::EndstonePlayer;
     friend class endstone::core::MinecraftCommandPermissions;
@@ -358,9 +360,13 @@ public:
         return std::move(std::make_unique<CommandType>());
     }
 
+    const Overload *registerOverload(const char *name, CommandVersion version, Overload::AllocFunction alloc,
+                                     std::vector<CommandParameterData> params);
+
     template <typename CommandType>
     const Overload *registerOverload(const char *name, CommandVersion version,
                                      std::vector<CommandParameterData> params);
+
     // Endstone ends
 
 private:
@@ -462,21 +468,26 @@ public:
     CustomStorageIsSetFn value_is_set_fn{nullptr};
 };
 
-template <typename CommandType>
-const CommandRegistry::Overload *CommandRegistry::registerOverload(const char *name, CommandVersion version,
-                                                                   std::vector<CommandParameterData> params)
+inline const CommandRegistry::Overload *CommandRegistry::registerOverload(const char *name, CommandVersion version,
+                                                                          Overload::AllocFunction alloc,
+                                                                          std::vector<CommandParameterData> params)
 {
     auto *signature = const_cast<Signature *>(findCommand(name));
     if (!signature) {
         return nullptr;
     }
 
-    auto overload = Overload(version, &allocateCommand<CommandType>);
+    auto &overload = signature->overloads.emplace_back(version, std::move(alloc));
     overload.params = std::move(params);
-
-    signature->overloads.push_back(overload);
     registerOverloadInternal(*signature, overload);
-    return &signature->overloads.back();
+    return &overload;
+}
+
+template <typename CommandType>
+const CommandRegistry::Overload *CommandRegistry::registerOverload(const char *name, CommandVersion version,
+                                                                   std::vector<CommandParameterData> params)
+{
+    return registerOverload(name, version, &allocateCommand<CommandType>, std::move(params));
 }
 
 template <>

--- a/src/bedrock/server/commands/command_selector.cpp
+++ b/src/bedrock/server/commands/command_selector.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bedrock/server/commands/command_selector.h"
+
+#include "bedrock/symbol.h"
+
+CommandResultVector CommandSelectorBase::newResults(const CommandOrigin &origin) const
+{
+    return BEDROCK_CALL(&CommandSelectorBase::newResults, this, origin);
+}
+
+const CommandRegistry::ParamParseRule &getCommandSelectorParseRule()
+{
+    static const auto *rule = BEDROCK_VAR(const CommandRegistry::ParamParseRule *,
+                                          "CommandRegistry::ParseRuleFor<CommandSelector<Actor>>::instance");
+    return *rule;
+}

--- a/src/bedrock/server/commands/command_selector.h
+++ b/src/bedrock/server/commands/command_selector.h
@@ -16,8 +16,10 @@
 
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "bedrock/bedrock.h"
@@ -48,6 +50,8 @@ using CommandResultVector = std::shared_ptr<std::vector<Actor *>>;
 
 class CommandSelectorBase {
 public:
+    static constexpr std::size_t Unlimited = 4294967295;
+
     using FilterFunc = std::function<bool(const CommandOrigin &, const Actor &)>;
 
     [[nodiscard]] CommandSelectionType getType() const { return type_; }
@@ -57,41 +61,53 @@ public:
     [[nodiscard]] bool isExplicitIdSelector() const { return is_explicit_id_selector_; }
 
 protected:
+    explicit CommandSelectorBase(bool force_player) : force_player_(force_player) {}
+
     [[nodiscard]] CommandResultVector newResults(const CommandOrigin &origin) const;
 
 private:
-    int version_;                                                            // +0
-    CommandSelectionType type_;                                              // +4
-    CommandSelectionOrder order_;                                            // +8
+    int version_{0};                                                         // +0
+    CommandSelectionType type_{CommandSelectionType::Self};                  // +4
+    CommandSelectionOrder order_{CommandSelectionOrder::Sorted};             // +8
     std::vector<InvertableFilter<std::string>> name_filters_;                // +16
     std::vector<InvertableFilter<ActorDefinitionIdentifier>> type_filters_;  // +40
     std::vector<InvertableFilter<HashedString>> family_filters_;             // +64
     std::vector<InvertableFilter<std::string>> tag_filters_;                 // +88
     std::vector<FilterFunc> filter_chain_;                                   // +112
-    CommandPosition position_;                                               // +136
-    Vec3 box_deltas_;                                                        // +152
-    float radius_min_sqr_;                                                   // +164
-    float radius_max_sqr_;                                                   // +168
-    std::size_t count_;                                                      // +176
-    bool include_dead_players_;                                              // +184
-    bool is_position_bound_;                                                 // +185
-    bool distance_filtered_;                                                 // +186
-    bool position_filtered_;                                                 // +187
-    bool count_filtered_;                                                    // +188
-    bool have_deltas_;                                                       // +189
-    bool force_player_;                                                      // +190
-    bool exclude_agents_;                                                    // +191
-    bool is_explicit_id_selector_;                                           // +192
-    bool force_dimension_filtering_;                                         // +193
-    bool is_name_filters_only_in_chain_;                                     // +194
+    CommandPosition position_{};                                             // +136
+    Vec3 box_deltas_{};                                                      // +152
+    float radius_min_sqr_{0.0F};                                             // +164
+    float radius_max_sqr_{std::numeric_limits<float>::max()};                // +168
+    std::size_t count_{Unlimited};                                           // +176
+    bool include_dead_players_{false};                                       // +184
+    bool is_position_bound_{false};                                          // +185
+    bool distance_filtered_{false};                                          // +186
+    bool position_filtered_{false};                                          // +187
+    bool count_filtered_{false};                                             // +188
+    bool have_deltas_{false};                                                // +189
+    bool force_player_{false};                                               // +190
+    bool exclude_agents_{false};                                             // +191
+    bool is_explicit_id_selector_{false};                                    // +192
+    bool force_dimension_filtering_{false};                                  // +193
+    bool is_name_filters_only_in_chain_{true};                               // +194
 };
 BEDROCK_STATIC_ASSERT_SIZE(CommandSelectorBase, 200, 200);
 
 template <typename T>
 class CommandSelector : public CommandSelectorBase {
 public:
+    CommandSelector() : CommandSelectorBase(std::is_same_v<T, ::Player>) {}
+
     using CommandSelectorBase::newResults;
 };
 
 using ActorSelector = CommandSelector<Actor>;
 using PlayerSelector = CommandSelector<Player>;
+
+/**
+ * The parse rule the command registry uses for a target selector.
+ *
+ * The actor and the player selector share one rule; which of the two a parameter yields is decided
+ * by the storage it is parsed into, not by the rule.
+ */
+const CommandRegistry::ParamParseRule &getCommandSelectorParseRule();

--- a/src/bedrock/server/commands/command_selector.h
+++ b/src/bedrock/server/commands/command_selector.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "bedrock/bedrock.h"
+#include "bedrock/core/math/vec3.h"
+#include "bedrock/core/string/string_hash.h"
+#include "bedrock/forward.h"
+#include "bedrock/server/commands/command.h"
+#include "bedrock/world/actor/actor_definition_identifier.h"
+#include "bedrock/world/actor/selectors/actor_selector.h"
+
+enum class CommandSelectionType : int {
+    Self = 0,
+    Entities = 1,
+    Players = 2,
+    DefaultPlayers = 3,
+    OwnedAgent = 4,
+    Agents = 5,
+    Initiator = 6,
+};
+
+enum class CommandSelectionOrder : int {
+    Sorted = 0,
+    InverseSorted = 1,
+    Random = 2,
+};
+
+using CommandResultVector = std::shared_ptr<std::vector<Actor *>>;
+
+class CommandSelectorBase {
+public:
+    using FilterFunc = std::function<bool(const CommandOrigin &, const Actor &)>;
+
+    [[nodiscard]] CommandSelectionType getType() const { return type_; }
+    [[nodiscard]] CommandSelectionOrder getOrder() const { return order_; }
+    [[nodiscard]] std::size_t getResultCount() const { return count_; }
+    [[nodiscard]] const CommandPosition &getPosition() const { return position_; }
+    [[nodiscard]] bool isExplicitIdSelector() const { return is_explicit_id_selector_; }
+
+protected:
+    [[nodiscard]] CommandResultVector newResults(const CommandOrigin &origin) const;
+
+private:
+    int version_;                                                            // +0
+    CommandSelectionType type_;                                              // +4
+    CommandSelectionOrder order_;                                            // +8
+    std::vector<InvertableFilter<std::string>> name_filters_;                // +16
+    std::vector<InvertableFilter<ActorDefinitionIdentifier>> type_filters_;  // +40
+    std::vector<InvertableFilter<HashedString>> family_filters_;             // +64
+    std::vector<InvertableFilter<std::string>> tag_filters_;                 // +88
+    std::vector<FilterFunc> filter_chain_;                                   // +112
+    CommandPosition position_;                                               // +136
+    Vec3 box_deltas_;                                                        // +152
+    float radius_min_sqr_;                                                   // +164
+    float radius_max_sqr_;                                                   // +168
+    std::size_t count_;                                                      // +176
+    bool include_dead_players_;                                              // +184
+    bool is_position_bound_;                                                 // +185
+    bool distance_filtered_;                                                 // +186
+    bool position_filtered_;                                                 // +187
+    bool count_filtered_;                                                    // +188
+    bool have_deltas_;                                                       // +189
+    bool force_player_;                                                      // +190
+    bool exclude_agents_;                                                    // +191
+    bool is_explicit_id_selector_;                                           // +192
+    bool force_dimension_filtering_;                                         // +193
+    bool is_name_filters_only_in_chain_;                                     // +194
+};
+BEDROCK_STATIC_ASSERT_SIZE(CommandSelectorBase, 200, 200);
+
+template <typename T>
+class CommandSelector : public CommandSelectorBase {
+public:
+    using CommandSelectorBase::newResults;
+};
+
+using ActorSelector = CommandSelector<Actor>;
+using PlayerSelector = CommandSelector<Player>;

--- a/src/bedrock/symbols/linux.h
+++ b/src/bedrock/symbols/linux.h
@@ -11,8 +11,9 @@
 
 namespace endstone::runtime {
 
-static constexpr std::array<std::pair<std::string_view, std::size_t>, 75> symbols = {{
+static constexpr std::array<std::pair<std::string_view, std::size_t>, 77> symbols = {{
     {"BlockState::StateListNode::mHead", 245468000},
+    {"CommandRegistry::ParseRuleFor<CommandSelector<Actor>>::instance", 244780312},
     {"Enchant::mEnchants", 245294016},
     {"MobEffect::mMobEffects", 245274360},
     {"Potion::mPotionsById", 245353632},
@@ -51,6 +52,8 @@ static constexpr std::array<std::pair<std::string_view, std::size_t>, 75> symbol
     {"_ZN15CommandRegistry24registerOverloadInternalERNS_9SignatureERNS_8OverloadE", 159975664},
     {"_ZNK15CommandRegistry14symbolToStringENS_6SymbolE", 159852320},
     {"_ZNK15CommandRegistry26serializeAvailableCommandsEv", 160039360},
+    // CommandSelectorBase
+    {"_ZNK19CommandSelectorBase10newResultsERK13CommandOrigin", 160056128},
     // CommandUtils
     {"_ZN12CommandUtils12getActorNameERK5Actor", 159774800},
     // CraftingDataPacketPayload

--- a/src/bedrock/symbols/windows.h
+++ b/src/bedrock/symbols/windows.h
@@ -11,8 +11,9 @@
 
 namespace endstone::runtime {
 
-static constexpr std::array<std::pair<std::string_view, std::size_t>, 75> symbols = {{
+static constexpr std::array<std::pair<std::string_view, std::size_t>, 77> symbols = {{
     {"BlockState::StateListNode::mHead", 211294960},
+    {"CommandRegistry::ParseRuleFor<CommandSelector<Actor>>::instance", 210651704},
     {"Enchant::mEnchants", 211141912},
     {"MobEffect::mMobEffects", 211424880},
     {"Potion::mPotionsById", 211501744},
@@ -50,6 +51,8 @@ static constexpr std::array<std::pair<std::string_view, std::size_t>, 75> symbol
     {"?registerOverloadInternal@CommandRegistry@@AEAAXAEAUSignature@1@AEAUOverload@1@@Z", 3589280},
     {"?serializeAvailableCommands@CommandRegistry@@QEBA?AVAvailableCommandsPacket@@XZ", 3654624},
     {"?symbolToString@CommandRegistry@@AEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@VSymbol@1@@Z", 3423632},
+    // CommandSelectorBase
+    {"?newResults@CommandSelectorBase@@IEBA?AV?$shared_ptr@V?$vector@PEAVActor@@V?$allocator@PEAVActor@@@std@@@std@@@std@@AEBVCommandOrigin@@@Z", 3682048},
     // CommandUtils
     {"?getActorName@CommandUtils@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBVActor@@@Z", 3711424},
     // CraftingDataPacketPayload

--- a/src/bedrock/world/actor/selectors/actor_selector.h
+++ b/src/bedrock/world/actor/selectors/actor_selector.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+template <typename T>
+struct InvertableFilter {
+    T value;
+    bool inverted;
+};

--- a/src/endstone/core/CMakeLists.txt
+++ b/src/endstone/core/CMakeLists.txt
@@ -58,6 +58,10 @@ add_library(endstone_core
         command/command_origin_wrapper.cpp
         command/command_sender.cpp
         command/command_usage_parser.cpp
+        command/tree/argument_types.cpp
+        command/tree/command_tree.cpp
+        command/tree/command_tree_registrar.cpp
+        command/tree/tree_command.cpp
         command/console_command_sender.cpp
         command/minecraft_command_adapter.cpp
         command/minecraft_command_wrapper.cpp

--- a/src/endstone/core/command/command_map.cpp
+++ b/src/endstone/core/command/command_map.cpp
@@ -143,13 +143,15 @@ bool EndstoneCommandMap::registerCommand(NotNull<LiteralCommandNode> root, Plugi
     for (const auto &overload : command->getOverloads()) {
         std::vector<CommandParameterData> param_data;
         param_data.reserve(overload.slots.size());
-        for (const auto &slot : overload.slots) {
+        for (std::size_t index = 0; index < overload.slots.size(); ++index) {
+            const auto &slot = overload.slots[index];
             auto data = slot.is_literal
-                          ? CommandTreeRegistrar::makeLiteralParameter(slot.node->getName(), *command, registry)
+                          ? CommandTreeRegistrar::makeLiteralParameter(slot.node->getName(), static_cast<int>(index),
+                                                                       *command, registry)
                           : CommandTreeRegistrar::makeArgumentParameter(
                                 slot.node->getName(),
                                 *static_cast<const ArgumentCommandNode *>(slot.node.get().get())->getArgumentType(),
-                                *command, registry);
+                                static_cast<int>(index), *command, registry);
             if (!data.has_value()) {
                 server_.getLogger().error("Plugin {} is unable to register command '{}'. {}", owner.getName(), name,
                                           data.error());

--- a/src/endstone/core/command/command_map.cpp
+++ b/src/endstone/core/command/command_map.cpp
@@ -105,7 +105,7 @@ bool EndstoneCommandMap::dispatch(const NotNull<CommandSender> &sender, std::str
         }
         try {
             if (const auto *tree = dynamic_cast<const TreeCommandAdapter *>(compiled)) {
-                return tree->runFrom(sender);
+                return tree->runFrom(sender, *command_origin);
             }
             return command->execute(sender, static_cast<const MinecraftCommandAdapter *>(compiled)->args_);
         }

--- a/src/endstone/core/command/command_map.cpp
+++ b/src/endstone/core/command/command_map.cpp
@@ -42,6 +42,9 @@
 #include "endstone/core/command/defaults/version_command.h"
 #include "endstone/core/command/minecraft_command_adapter.h"
 #include "endstone/core/command/minecraft_command_wrapper.h"
+#include "endstone/core/command/tree/command_tree.h"
+#include "endstone/core/command/tree/command_tree_registrar.h"
+#include "endstone/core/command/tree/tree_command.h"
 #include "endstone/core/devtools/devtools_command.h"
 #include "endstone/core/permissions/default_permissions.h"
 #include "endstone/core/server.h"
@@ -101,6 +104,9 @@ bool EndstoneCommandMap::dispatch(const NotNull<CommandSender> &sender, std::str
             return false;
         }
         try {
+            if (const auto *tree = dynamic_cast<const TreeCommandAdapter *>(compiled)) {
+                return tree->runFrom(sender);
+            }
             return command->execute(sender, static_cast<const MinecraftCommandAdapter *>(compiled)->args_);
         }
         catch (const std::exception &e) {
@@ -108,6 +114,87 @@ bool EndstoneCommandMap::dispatch(const NotNull<CommandSender> &sender, std::str
             return false;
         }
     }
+}
+
+bool EndstoneCommandMap::registerCommand(NotNull<LiteralCommandNode> root, Plugin &owner)
+{
+    std::lock_guard lock(mutex_);
+    auto &registry = getHandle().getRegistry();
+
+    auto name = root->getName();
+    std::ranges::transform(name, name.begin(), [](unsigned char c) { return std::tolower(c); });
+    if (getCommand(name) != nullptr) {
+        server_.getLogger().error("Plugin {} is unable to register command '{}' as it already exists.", owner.getName(),
+                                  name);
+        return false;
+    }
+
+    auto flattened = flattenCommandTree(root);
+    if (!flattened.has_value()) {
+        server_.getLogger().error("Plugin {} is unable to register command '{}'. {}", owner.getName(), name,
+                                  flattened.error());
+        return false;
+    }
+
+    auto command = std::make_shared<TreeCommand>(root, std::move(flattened.value()));
+
+    std::vector<std::vector<CommandParameterData>> pending_param_data;
+    pending_param_data.reserve(command->getOverloads().size());
+    for (const auto &overload : command->getOverloads()) {
+        std::vector<CommandParameterData> param_data;
+        param_data.reserve(overload.slots.size());
+        for (const auto &slot : overload.slots) {
+            auto data = slot.is_literal
+                          ? CommandTreeRegistrar::makeLiteralParameter(slot.node->getName(), *command, registry)
+                          : CommandTreeRegistrar::makeArgumentParameter(
+                                slot.node->getName(),
+                                *static_cast<const ArgumentCommandNode *>(slot.node.get().get())->getArgumentType(),
+                                *command, registry);
+            if (!data.has_value()) {
+                server_.getLogger().error("Plugin {} is unable to register command '{}'. {}", owner.getName(), name,
+                                          data.error());
+                return false;
+            }
+            param_data.push_back(std::move(data.value()));
+        }
+        pending_param_data.push_back(std::move(param_data));
+    }
+
+    std::vector<std::string> pending_aliases;
+    for (const auto &alias : command->getAliases()) {
+        if (getCommand(alias) == nullptr) {
+            pending_aliases.push_back(alias);
+        }
+    }
+
+    registry.registerCommand(name, command->getDescription().c_str(), CommandPermissionLevel::Any,
+                             CommandCheatFlag::NotCheat, CommandUsageFlag::Normal);
+    custom_commands_.emplace(name, command);
+    for (const auto &alias : pending_aliases) {
+        registry.registerAlias(name, alias);
+        custom_commands_.emplace(alias, command);
+    }
+
+    const auto *raw = command.get();
+    for (std::size_t i = 0; i < pending_param_data.size(); ++i) {
+        const auto *overload = &raw->getOverloads()[i];
+        registry.registerOverload(
+            name.c_str(), {1, INT_MAX},
+            [raw, overload]() -> std::unique_ptr<::Command> {
+                return std::make_unique<TreeCommandAdapter>(*raw, *overload);
+            },
+            pending_param_data[i]);
+    }
+
+    command->setAliases(pending_aliases);
+    command->registerTo(*this);
+    return true;
+}
+
+void EndstoneCommandMap::setSuggestions(std::string name, std::vector<std::string> values)
+{
+    std::lock_guard lock(mutex_);
+    CommandTreeRegistrar::setSoftEnumValues(name, std::move(values), getHandle().getRegistry());
 }
 
 void EndstoneCommandMap::clearCommands()

--- a/src/endstone/core/command/command_map.h
+++ b/src/endstone/core/command/command_map.h
@@ -20,6 +20,7 @@
 #include "bedrock/server/commands/minecraft_commands.h"
 #include "endstone/command/command.h"
 #include "endstone/command/command_map.h"
+#include "endstone/command/command_node.h"
 
 namespace endstone::core {
 
@@ -29,6 +30,8 @@ public:
     explicit EndstoneCommandMap(EndstoneServer &server);
     using CommandMap::registerCommand;
     bool registerCommand(NotNull<Command> command) override;
+    bool registerCommand(NotNull<LiteralCommandNode> root, Plugin &owner) override;
+    void setSuggestions(std::string name, std::vector<std::string> values) override;
     bool dispatch(const NotNull<CommandSender> &sender, std::string command_line) const override;
     void clearCommands() override;
     [[nodiscard]] Nullable<Command> getCommand(std::string name) const override;

--- a/src/endstone/core/command/minecraft_command_adapter.cpp
+++ b/src/endstone/core/command/minecraft_command_adapter.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "endstone/core/command/command_origin_wrapper.h"
+#include "endstone/core/command/parse_token_text.h"
 
 namespace endstone::core {
 
@@ -40,95 +41,6 @@ void MinecraftCommandAdapter::execute(const CommandOrigin &origin, CommandOutput
 
 }  // namespace endstone::core
 
-namespace {
-std::string_view removeQuotes(const std::string_view &str)
-{
-    if (str.size() < 2) {
-        return str;
-    }
-    if (str.front() == '"' && str.back() == '"') {
-        return str.substr(1, str.size() - 2);
-    }
-    return str;
-}
-
-const CommandRegistry::ParseToken *findFirstWithText(const CommandRegistry::ParseToken *node)
-{
-    if (!node) {
-        return nullptr;
-    }
-
-    // Check current node first (pre-order)
-    if (node->text) {
-        return node;
-    }
-
-    // Recurse into child
-    if (const CommandRegistry::ParseToken *found = findFirstWithText(node->child.get())) {
-        return found;
-    }
-
-    // Recurse into next sibling
-    return findFirstWithText(node->next.get());
-}
-
-std::string_view rstrip(std::string_view str, std::string_view chars = " \t\n\r\f\v")
-{
-    size_t end = str.size();
-    while (end > 0 && chars.find(str[end - 1]) != std::string_view::npos) {
-        --end;
-    }
-    return str.substr(0, end);
-}
-
-std::optional<std::string_view> parseNode(const CommandRegistry::ParseToken &root)
-{
-    // If there are no children, this is a leaf text node.
-    if (!root.child) {
-        if (root.length == 0) {
-            return std::nullopt;
-        }
-        if (root.type == CommandRegistry::HardNonTerminal::Id) {
-            return removeQuotes({root.text, root.length});
-        }
-        return std::string_view{root.text, root.length};
-    }
-
-    // Otherwise:
-    const auto &child = *root.child;
-    const auto *begin = findFirstWithText(&child);
-    if (!begin) {
-        return std::nullopt;
-    }
-
-    // (1) If this node has no next sibling, it's the last argument: consume all remaining text until the end
-    if (!root.next) {
-        const auto view = rstrip(begin->text);
-        if (child.type == CommandRegistry::HardNonTerminal::Id) {
-            return removeQuotes(view);
-        }
-        return view;
-    }
-
-    // (2) Otherwise, find the start of the next argument and extract the substring between begin and end, then trim
-    // trailing whitespace.
-    const auto *end = findFirstWithText(root.next.get());
-    if (!end) {
-        const auto view = rstrip(begin->text);
-        if (child.type == CommandRegistry::HardNonTerminal::Id) {
-            return removeQuotes(view);
-        }
-        return view;
-    }
-
-    const auto view = rstrip({begin->text, end->text});
-    if (child.type == CommandRegistry::HardNonTerminal::Id) {
-        return removeQuotes(view);
-    }
-    return view;
-}
-}  // namespace
-
 template <>
 bool CommandRegistry::parse<endstone::core::MinecraftCommandAdapter>(void *storage, const ParseToken &token,
                                                                      const CommandOrigin &origin, int version,
@@ -139,7 +51,7 @@ bool CommandRegistry::parse<endstone::core::MinecraftCommandAdapter>(void *stora
         return false;
     }
     auto &output = static_cast<endstone::core::MinecraftCommandAdapter *>(storage)->args_;
-    if (auto result = parseNode(token)) {
+    if (auto result = endstone::core::parseNode(token)) {
         output.emplace_back(*result);
     }
     return true;

--- a/src/endstone/core/command/parse_token_text.h
+++ b/src/endstone/core/command/parse_token_text.h
@@ -1,0 +1,111 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "bedrock/server/commands/command_registry.h"
+
+namespace endstone::core {
+
+inline std::string_view removeQuotes(const std::string_view &str)
+{
+    if (str.size() < 2) {
+        return str;
+    }
+    if (str.front() == '"' && str.back() == '"') {
+        return str.substr(1, str.size() - 2);
+    }
+    return str;
+}
+
+inline const CommandRegistry::ParseToken *findFirstWithText(const CommandRegistry::ParseToken *node)
+{
+    if (!node) {
+        return nullptr;
+    }
+
+    // Check current node first (pre-order)
+    if (node->text) {
+        return node;
+    }
+
+    // Recurse into child
+    if (const CommandRegistry::ParseToken *found = findFirstWithText(node->child.get())) {
+        return found;
+    }
+
+    // Recurse into next sibling
+    return findFirstWithText(node->next.get());
+}
+
+inline std::string_view rstrip(std::string_view str, std::string_view chars = " \t\n\r\f\v")
+{
+    size_t end = str.size();
+    while (end > 0 && chars.find(str[end - 1]) != std::string_view::npos) {
+        --end;
+    }
+    return str.substr(0, end);
+}
+
+inline std::optional<std::string_view> parseNode(const CommandRegistry::ParseToken &root)
+{
+    // If there are no children, this is a leaf text node.
+    if (!root.child) {
+        if (root.length == 0) {
+            return std::nullopt;
+        }
+        if (root.type == CommandRegistry::HardNonTerminal::Id) {
+            return removeQuotes({root.text, root.length});
+        }
+        return std::string_view{root.text, root.length};
+    }
+
+    // Otherwise:
+    const auto &child = *root.child;
+    const auto *begin = findFirstWithText(&child);
+    if (!begin) {
+        return std::nullopt;
+    }
+
+    // (1) If this node has no next sibling, it's the last argument: consume all remaining text until the end
+    if (!root.next) {
+        const auto view = rstrip(begin->text);
+        if (child.type == CommandRegistry::HardNonTerminal::Id) {
+            return removeQuotes(view);
+        }
+        return view;
+    }
+
+    // (2) Otherwise, find the start of the next argument and extract the substring between begin and end, then trim
+    // trailing whitespace.
+    const auto *end = findFirstWithText(root.next.get());
+    if (!end) {
+        const auto view = rstrip(begin->text);
+        if (child.type == CommandRegistry::HardNonTerminal::Id) {
+            return removeQuotes(view);
+        }
+        return view;
+    }
+
+    const auto view = rstrip({begin->text, end->text});
+    if (child.type == CommandRegistry::HardNonTerminal::Id) {
+        return removeQuotes(view);
+    }
+    return view;
+}
+
+}  // namespace endstone::core

--- a/src/endstone/core/command/tree/argument_types.cpp
+++ b/src/endstone/core/command/tree/argument_types.cpp
@@ -20,7 +20,11 @@
 
 #include <nlohmann/json.hpp>
 
+#include "bedrock/world/actor/actor.h"
+#include "bedrock/world/actor/player/player.h"
+#include "endstone/actor/actor.h"
 #include "endstone/command/command_error.h"
+#include "endstone/player.h"
 
 namespace endstone::core {
 
@@ -51,6 +55,46 @@ float parseFloat(const std::string &text, const std::string_view name)
     catch (const std::exception &) {
         throw CommandError(std::format("'{}' is not a number for '{}'.", text, name));
     }
+}
+
+std::vector<NotNull<Actor>> toActors(const CommandResultVector &results)
+{
+    std::vector<NotNull<Actor>> actors;
+    if (!results) {
+        return actors;
+    }
+    for (auto *actor : *results) {
+        if (actor) {
+            actors.emplace_back(actor->getEndstoneActor<Actor>());
+        }
+    }
+    return actors;
+}
+
+std::vector<NotNull<Player>> toPlayers(const CommandResultVector &results)
+{
+    std::vector<NotNull<Player>> players;
+    if (!results) {
+        return players;
+    }
+    for (auto *actor : *results) {
+        if (actor && actor->isPlayer()) {
+            players.emplace_back(actor->getEndstoneActor<Player>());
+        }
+    }
+    return players;
+}
+
+template <typename T>
+T requireExactlyOne(std::vector<T> matched)
+{
+    if (matched.empty()) {
+        throw CommandError("No targets matched selector");
+    }
+    if (matched.size() > 1) {
+        throw CommandError("This argument accepts a single target, but the selector matched more than one");
+    }
+    return matched.front();
 }
 
 }  // namespace
@@ -96,6 +140,41 @@ ArgumentValue convertArgument(const ArgumentType &type, const std::string &text,
     }
     default:
         return ArgumentValue::of(text);
+    }
+}
+
+ArgumentValue convertSelector(const ArgumentType &type, const CommandResultVector &results,
+                              const NotNull<CommandSender> &sender)
+{
+    if (type.getKind() == ArgumentKind::Custom) {
+        const auto native = type.getNativeType();
+        if (!native) {
+            throw CommandError("This argument has no native type to parse as.");
+        }
+        return type.convert(convertSelector(*native, results, sender), sender);
+    }
+
+    switch (type.getKind()) {
+    case ArgumentKind::Player:
+        return ArgumentValue::of(requireExactlyOne(toPlayers(results)));
+    case ArgumentKind::Players: {
+        auto players = toPlayers(results);
+        if (players.empty()) {
+            throw CommandError("No targets matched selector");
+        }
+        return ArgumentValue::of(std::move(players));
+    }
+    case ArgumentKind::Entity:
+        return ArgumentValue::of(requireExactlyOne(toActors(results)));
+    case ArgumentKind::Entities: {
+        auto actors = toActors(results);
+        if (actors.empty()) {
+            throw CommandError("No targets matched selector");
+        }
+        return ArgumentValue::of(std::move(actors));
+    }
+    default:
+        throw CommandError("This argument is not a target selector.");
     }
 }
 

--- a/src/endstone/core/command/tree/argument_types.cpp
+++ b/src/endstone/core/command/tree/argument_types.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "endstone/core/command/tree/argument_types.h"
+
+#include <charconv>
+#include <format>
+#include <stdexcept>
+
+#include <nlohmann/json.hpp>
+
+#include "endstone/command/command_error.h"
+
+namespace endstone::core {
+
+namespace {
+
+int parseInteger(const std::string &text, const std::string_view name)
+{
+    int value = 0;
+    const auto *first = text.data();
+    const auto *last = text.data() + text.size();
+    const auto [ptr, ec] = std::from_chars(first, last, value);
+    if (ec != std::errc{} || ptr != last) {
+        throw CommandError(std::format("'{}' is not a whole number for '{}'.", text, name));
+    }
+    return value;
+}
+
+float parseFloat(const std::string &text, const std::string_view name)
+{
+    try {
+        std::size_t consumed = 0;
+        const float value = std::stof(text, &consumed);
+        if (consumed != text.size()) {
+            throw std::invalid_argument("trailing characters");
+        }
+        return value;
+    }
+    catch (const std::exception &) {
+        throw CommandError(std::format("'{}' is not a number for '{}'.", text, name));
+    }
+}
+
+}  // namespace
+
+ArgumentValue convertArgument(const ArgumentType &type, const std::string &text, const NotNull<CommandSender> &sender)
+{
+    switch (type.getKind()) {
+    case ArgumentKind::Boolean:
+        return ArgumentValue::of(text == "true" || text == "1");
+    case ArgumentKind::Integer: {
+        const auto &builtin = static_cast<const BuiltinArgumentType &>(type);
+        const auto value = parseInteger(text, "integer");
+        if (value < builtin.getMinimum() || value > builtin.getMaximum()) {
+            throw CommandError(std::format("{} is out of range: expected {} to {}.", value,
+                                           static_cast<long long>(builtin.getMinimum()),
+                                           static_cast<long long>(builtin.getMaximum())));
+        }
+        return ArgumentValue::of(value);
+    }
+    case ArgumentKind::Float: {
+        const auto &builtin = static_cast<const BuiltinArgumentType &>(type);
+        const auto value = parseFloat(text, "number");
+        if (value < builtin.getMinimum() || value > builtin.getMaximum()) {
+            throw CommandError(std::format("{} is out of range: expected {} to {}.", value, builtin.getMinimum(),
+                                           builtin.getMaximum()));
+        }
+        return ArgumentValue::of(value);
+    }
+    case ArgumentKind::Json: {
+        try {
+            return ArgumentValue::of(nlohmann::json::parse(text));
+        }
+        catch (const nlohmann::json::exception &e) {
+            throw CommandError(std::format("'{}' is not valid JSON: {}", text, e.what()));
+        }
+    }
+    case ArgumentKind::Custom: {
+        const auto native = type.getNativeType();
+        if (!native) {
+            throw CommandError("This argument has no native type to parse as.");
+        }
+        return type.convert(convertArgument(*native, text, sender), sender);
+    }
+    default:
+        return ArgumentValue::of(text);
+    }
+}
+
+}  // namespace endstone::core

--- a/src/endstone/core/command/tree/argument_types.h
+++ b/src/endstone/core/command/tree/argument_types.h
@@ -16,10 +16,42 @@
 
 #include <string>
 
+#include "bedrock/server/commands/command_selector.h"
 #include "endstone/command/argument_type.h"
 #include "endstone/command/command_sender.h"
 
 namespace endstone::core {
+
+/**
+ * Returns the built-in type an argument ends up being parsed as.
+ *
+ * A custom argument type borrows a built-in type's grammar, so follow the chain to whichever
+ * built-in actually reaches the command registry.
+ */
+inline ArgumentKind effectiveArgumentKind(const ArgumentType &type)
+{
+    if (type.getKind() != ArgumentKind::Custom) {
+        return type.getKind();
+    }
+    const auto native = type.getNativeType();
+    return native ? effectiveArgumentKind(*native) : ArgumentKind::Custom;
+}
+
+/**
+ * Returns whether an argument of this kind is parsed into a target selector.
+ */
+inline bool isSelectorArgument(const ArgumentKind kind)
+{
+    switch (kind) {
+    case ArgumentKind::Player:
+    case ArgumentKind::Players:
+    case ArgumentKind::Entity:
+    case ArgumentKind::Entities:
+        return true;
+    default:
+        return false;
+    }
+}
 
 /**
  * Converts the text the command registry parsed into the argument's value.
@@ -27,5 +59,14 @@ namespace endstone::core {
  * Throws CommandError if the text does not satisfy the argument's constraints.
  */
 ArgumentValue convertArgument(const ArgumentType &type, const std::string &text, const NotNull<CommandSender> &sender);
+
+/**
+ * Converts the actors a target selector matched into the argument's value.
+ *
+ * Throws CommandError if the selector matched nothing, or matched more than one where the argument
+ * accepts a single target.
+ */
+ArgumentValue convertSelector(const ArgumentType &type, const CommandResultVector &results,
+                              const NotNull<CommandSender> &sender);
 
 }  // namespace endstone::core

--- a/src/endstone/core/command/tree/argument_types.h
+++ b/src/endstone/core/command/tree/argument_types.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "endstone/command/argument_type.h"
+#include "endstone/command/command_sender.h"
+
+namespace endstone::core {
+
+/**
+ * Converts the text the command registry parsed into the argument's value.
+ *
+ * Throws CommandError if the text does not satisfy the argument's constraints.
+ */
+ArgumentValue convertArgument(const ArgumentType &type, const std::string &text, const NotNull<CommandSender> &sender);
+
+}  // namespace endstone::core

--- a/src/endstone/core/command/tree/command_tree.cpp
+++ b/src/endstone/core/command/tree/command_tree.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "endstone/core/command/tree/command_tree.h"
+
+#include <algorithm>
+#include <format>
+
+namespace endstone::core {
+
+namespace {
+
+bool isArgument(const NotNull<CommandNode> &node)
+{
+    return node->getType() == CommandNodeType::Argument;
+}
+
+bool isGreedy(const NotNull<CommandNode> &node)
+{
+    if (!isArgument(node)) {
+        return false;
+    }
+    const auto kind = static_cast<const ArgumentCommandNode *>(node.get().get())->getArgumentType()->getKind();
+    return kind == ArgumentKind::Message || kind == ArgumentKind::RawText;
+}
+
+std::string describePath(const std::vector<NotNull<CommandNode>> &path)
+{
+    std::string result;
+    for (const auto &node : path) {
+        if (!result.empty()) {
+            result += " ";
+        }
+        result += node->getName();
+    }
+    return result;
+}
+
+nonstd::expected<void, std::string> walk(const NotNull<CommandNode> &node, std::vector<NotNull<CommandNode>> &path,
+                                         std::vector<CommandTreeSlot> &slots, std::vector<CommandTreeOverload> &out)
+{
+    if (std::ranges::any_of(path, [&node](const auto &seen) { return seen.get() == node.get(); })) {
+        return nonstd::make_unexpected(std::format(
+            "'{}' is reachable from itself, which cannot be represented as a command.", describePath(path)));
+    }
+
+    path.push_back(node);
+
+    if (node->isExecutable()) {
+        if (out.size() >= MAX_OVERLOADS_PER_COMMAND) {
+            return nonstd::make_unexpected(std::format("Too many branches: '{}' flattens to more than {} overloads.",
+                                                       describePath(path), MAX_OVERLOADS_PER_COMMAND));
+        }
+        out.push_back({slots, path, node});
+    }
+
+    if (!node->getChildren().empty() && isGreedy(node)) {
+        return nonstd::make_unexpected(std::format(
+            "Argument '{}' consumes the rest of the line, so it must be the last one on its branch.", node->getName()));
+    }
+
+    for (const auto &child : node->getChildren()) {
+        slots.push_back({child, !isArgument(child)});
+        auto result = walk(child, path, slots, out);
+        if (!result.has_value()) {
+            return result;
+        }
+        slots.pop_back();
+    }
+
+    path.pop_back();
+    return {};
+}
+
+}  // namespace
+
+nonstd::expected<std::vector<CommandTreeOverload>, std::string> flattenCommandTree(const NotNull<CommandNode> &root)
+{
+    std::vector<CommandTreeOverload> out;
+    std::vector<NotNull<CommandNode>> path;
+    std::vector<CommandTreeSlot> slots;
+
+    auto result = walk(root, path, slots, out);
+    if (!result.has_value()) {
+        return nonstd::make_unexpected(result.error());
+    }
+
+    if (out.empty()) {
+        return nonstd::make_unexpected(std::format(
+            "'{}' has no branch that does anything. Add executes() to at least one node.", root->getName()));
+    }
+    return out;
+}
+
+}  // namespace endstone::core

--- a/src/endstone/core/command/tree/command_tree.h
+++ b/src/endstone/core/command/tree/command_tree.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <nonstd/expected.hpp>
+
+#include "endstone/command/command_node.h"
+
+namespace endstone::core {
+
+/**
+ * One parameter of a flattened overload.
+ */
+struct CommandTreeSlot {
+    NotNull<CommandNode> node;
+    bool is_literal;
+};
+
+/**
+ * One root-to-leaf path of a command tree, as a flat parameter list.
+ */
+struct CommandTreeOverload {
+    std::vector<CommandTreeSlot> slots;
+    std::vector<NotNull<CommandNode>> path;
+    NotNull<CommandNode> leaf;
+};
+
+/**
+ * The maximum number of overloads a single command tree may flatten to.
+ *
+ * The full command list is serialized and sent to every player, so a tree that fans out without
+ * bound would cost every client real bandwidth.
+ */
+constexpr std::size_t MAX_OVERLOADS_PER_COMMAND = 64;
+
+/**
+ * Flattens a command tree into the overloads the command registry accepts.
+ *
+ * Returns an error message describing the offending branch if the tree cannot be represented.
+ */
+nonstd::expected<std::vector<CommandTreeOverload>, std::string> flattenCommandTree(const NotNull<CommandNode> &root);
+
+}  // namespace endstone::core

--- a/src/endstone/core/command/tree/command_tree_registrar.cpp
+++ b/src/endstone/core/command/tree/command_tree_registrar.cpp
@@ -16,6 +16,7 @@
 
 #include <format>
 
+#include "bedrock/server/commands/command_selector.h"
 #include "endstone/core/command/tree/tree_command.h"
 
 namespace endstone::core {
@@ -144,6 +145,14 @@ nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::makeAr
         return hardNonTerminalParameter(name, HardNonTerminal::RawText, index, command);
     case ArgumentKind::Json:
         return hardNonTerminalParameter(name, HardNonTerminal::JsonObject, index, command);
+    case ArgumentKind::Player:
+    case ArgumentKind::Players:
+    case ArgumentKind::Entity:
+    case ArgumentKind::Entities: {
+        auto data = basicParameter(name, index, command);
+        data.parse_rule = &getCommandSelectorParseRule();
+        return data;
+    }
     case ArgumentKind::Enumeration: {
         const auto &builtin = static_cast<const BuiltinArgumentType &>(type);
         return newEnumParameter(name, builtin.getName(), builtin.getValues(), index, command, registry);

--- a/src/endstone/core/command/tree/command_tree_registrar.cpp
+++ b/src/endstone/core/command/tree/command_tree_registrar.cpp
@@ -1,0 +1,173 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "endstone/core/command/tree/command_tree_registrar.h"
+
+#include <format>
+
+#include "endstone/core/command/tree/tree_command.h"
+
+namespace endstone::core {
+
+CommandParameterData CommandTreeRegistrar::basicParameter(const std::string &name, TreeCommand &command)
+{
+    return CommandParameterData({0}, &CommandRegistry::ParseRuleFor<TreeCommandAdapter>::instance, command.intern(name),
+                                CommandParameterDataType::Basic, nullptr, nullptr, 0, false, -1);
+}
+
+std::string CommandTreeRegistrar::uniqueEnumName(const std::string &wanted, const CommandRegistry &registry)
+{
+    std::string name = wanted;
+    int suffix = 0;
+    while (true) {
+        const auto it = registry.enum_lookup_.find(name);
+        if (it == registry.enum_lookup_.end() || registry.enums_.at(it->second).values.empty()) {
+            return name;
+        }
+        name = std::format("{}_{}", wanted, ++suffix);
+    }
+}
+
+nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::existingEnumParameter(
+    const std::string &name, const char *enum_name, TreeCommand &command, CommandRegistry &registry)
+{
+    const auto it = registry.enum_lookup_.find(enum_name);
+    if (it == registry.enum_lookup_.end()) {
+        return nonstd::make_unexpected(std::format("The command registry has no enum named '{}'.", enum_name));
+    }
+    auto data = basicParameter(name, command);
+    data.param_type = CommandParameterDataType::Enum;
+    data.enum_name_or_postfix = it->first.c_str();
+    data.enum_or_postfix_symbol = CommandRegistry::Symbol::fromEnumIndex(it->second).value();
+    return data;
+}
+
+nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::newEnumParameter(
+    const std::string &name, const std::string &wanted_enum_name, const std::vector<std::string> &values,
+    TreeCommand &command, CommandRegistry &registry)
+{
+    if (values.empty()) {
+        return nonstd::make_unexpected(std::format("Enum '{}' has no values.", wanted_enum_name));
+    }
+
+    const auto enum_name = uniqueEnumName(wanted_enum_name, registry);
+    const auto symbol = registry.addEnumValues(enum_name, values);
+    const auto it = registry.enum_lookup_.find(enum_name);
+    if (it == registry.enum_lookup_.end()) {
+        return nonstd::make_unexpected(std::format("Unable to register enum '{}'.", enum_name));
+    }
+
+    auto data = basicParameter(name, command);
+    data.param_type = CommandParameterDataType::Enum;
+    data.enum_name_or_postfix = it->first.c_str();
+    data.enum_or_postfix_symbol = symbol;
+    data.options = CommandParameterOption::EnumAutocompleteExpansion;
+    return data;
+}
+
+std::uint32_t CommandTreeRegistrar::findOrCreateSoftEnum(const std::string &name, CommandRegistry &registry)
+{
+    const auto it = registry.soft_enum_lookup_.find(name);
+    if (it != registry.soft_enum_lookup_.end()) {
+        return it->second;
+    }
+    const auto index = static_cast<std::uint32_t>(registry.soft_enums_.size());
+    registry.soft_enums_.push_back({name, {}});
+    registry.soft_enum_lookup_.emplace(name, index);
+    return index;
+}
+
+nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::softEnumParameter(
+    const std::string &name, const std::string &enum_name, TreeCommand &command, CommandRegistry &registry)
+{
+    if (enum_name.empty()) {
+        return nonstd::make_unexpected(std::format("Argument '{}' is a soft enum without a name.", name));
+    }
+    const auto index = findOrCreateSoftEnum(enum_name, registry);
+
+    auto data = basicParameter(name, command);
+    data.param_type = CommandParameterDataType::SoftEnum;
+    data.enum_name_or_postfix = registry.soft_enums_.at(index).name.c_str();
+    data.enum_or_postfix_symbol = CommandRegistry::Symbol::fromSoftEnumIndex(index).value();
+    return data;
+}
+
+nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::hardNonTerminalParameter(
+    const std::string &name, CommandRegistry::HardNonTerminal symbol, TreeCommand &command)
+{
+    auto data = basicParameter(name, command);
+    data.chained_subcommand_symbol = static_cast<int>(symbol);
+    return data;
+}
+
+nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::makeLiteralParameter(
+    const std::string &literal, TreeCommand &command, CommandRegistry &registry)
+{
+    return newEnumParameter(literal, literal, {literal}, command, registry);
+}
+
+nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::makeArgumentParameter(
+    const std::string &name, const ArgumentType &type, TreeCommand &command, CommandRegistry &registry)
+{
+    using HardNonTerminal = CommandRegistry::HardNonTerminal;
+
+    switch (type.getKind()) {
+    case ArgumentKind::Boolean:
+        return existingEnumParameter(name, "Boolean", command, registry);
+    case ArgumentKind::BlockType:
+        return existingEnumParameter(name, "Block", command, registry);
+    case ArgumentKind::EntityType:
+        return existingEnumParameter(name, "EntityType", command, registry);
+    case ArgumentKind::Integer:
+        return hardNonTerminalParameter(name, HardNonTerminal::Int, command);
+    case ArgumentKind::Float:
+        return hardNonTerminalParameter(name, HardNonTerminal::Val, command);
+    case ArgumentKind::String:
+        return hardNonTerminalParameter(name, HardNonTerminal::Id, command);
+    case ArgumentKind::Message:
+        return hardNonTerminalParameter(name, HardNonTerminal::MessageRoot, command);
+    case ArgumentKind::RawText:
+        return hardNonTerminalParameter(name, HardNonTerminal::RawText, command);
+    case ArgumentKind::Json:
+        return hardNonTerminalParameter(name, HardNonTerminal::JsonObject, command);
+    case ArgumentKind::Enumeration: {
+        const auto &builtin = static_cast<const BuiltinArgumentType &>(type);
+        return newEnumParameter(name, builtin.getName(), builtin.getValues(), command, registry);
+    }
+    case ArgumentKind::SoftEnum: {
+        const auto &builtin = static_cast<const BuiltinArgumentType &>(type);
+        return softEnumParameter(name, builtin.getName(), command, registry);
+    }
+    case ArgumentKind::Custom: {
+        const auto native = type.getNativeType();
+        if (!native) {
+            return nonstd::make_unexpected(std::format(
+                "Argument '{}' is a custom type but does not name a native type to be presented as.", name));
+        }
+        return makeArgumentParameter(name, *native, command, registry);
+    }
+    default:
+        return nonstd::make_unexpected(std::format("Argument '{}' uses a type that is not supported yet.", name));
+    }
+}
+
+bool CommandTreeRegistrar::setSoftEnumValues(const std::string &name, std::vector<std::string> values,
+                                             CommandRegistry &registry)
+{
+    findOrCreateSoftEnum(name, registry);
+    registry.setSoftEnumValues(name, std::move(values));
+    return true;
+}
+
+}  // namespace endstone::core

--- a/src/endstone/core/command/tree/command_tree_registrar.cpp
+++ b/src/endstone/core/command/tree/command_tree_registrar.cpp
@@ -20,10 +20,13 @@
 
 namespace endstone::core {
 
-CommandParameterData CommandTreeRegistrar::basicParameter(const std::string &name, TreeCommand &command)
+CommandParameterData CommandTreeRegistrar::basicParameter(const std::string &name, int index, TreeCommand &command)
 {
-    return CommandParameterData({0}, &CommandRegistry::ParseRuleFor<TreeCommandAdapter>::instance, command.intern(name),
-                                CommandParameterDataType::Basic, nullptr, nullptr, 0, false, -1);
+    auto data =
+        CommandParameterData({0}, &CommandRegistry::ParseRuleFor<TreeCommandAdapter>::instance, command.intern(name),
+                             CommandParameterDataType::Basic, nullptr, nullptr, index, false, -1);
+    data.value_get_fn = &TreeCommandAdapter::getStorageValue;
+    return data;
 }
 
 std::string CommandTreeRegistrar::uniqueEnumName(const std::string &wanted, const CommandRegistry &registry)
@@ -40,13 +43,13 @@ std::string CommandTreeRegistrar::uniqueEnumName(const std::string &wanted, cons
 }
 
 nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::existingEnumParameter(
-    const std::string &name, const char *enum_name, TreeCommand &command, CommandRegistry &registry)
+    const std::string &name, const char *enum_name, int index, TreeCommand &command, CommandRegistry &registry)
 {
     const auto it = registry.enum_lookup_.find(enum_name);
     if (it == registry.enum_lookup_.end()) {
         return nonstd::make_unexpected(std::format("The command registry has no enum named '{}'.", enum_name));
     }
-    auto data = basicParameter(name, command);
+    auto data = basicParameter(name, index, command);
     data.param_type = CommandParameterDataType::Enum;
     data.enum_name_or_postfix = it->first.c_str();
     data.enum_or_postfix_symbol = CommandRegistry::Symbol::fromEnumIndex(it->second).value();
@@ -54,7 +57,7 @@ nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::existi
 }
 
 nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::newEnumParameter(
-    const std::string &name, const std::string &wanted_enum_name, const std::vector<std::string> &values,
+    const std::string &name, const std::string &wanted_enum_name, const std::vector<std::string> &values, int index,
     TreeCommand &command, CommandRegistry &registry)
 {
     if (values.empty()) {
@@ -68,7 +71,7 @@ nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::newEnu
         return nonstd::make_unexpected(std::format("Unable to register enum '{}'.", enum_name));
     }
 
-    auto data = basicParameter(name, command);
+    auto data = basicParameter(name, index, command);
     data.param_type = CommandParameterDataType::Enum;
     data.enum_name_or_postfix = it->first.c_str();
     data.enum_or_postfix_symbol = symbol;
@@ -89,65 +92,65 @@ std::uint32_t CommandTreeRegistrar::findOrCreateSoftEnum(const std::string &name
 }
 
 nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::softEnumParameter(
-    const std::string &name, const std::string &enum_name, TreeCommand &command, CommandRegistry &registry)
+    const std::string &name, const std::string &enum_name, int index, TreeCommand &command, CommandRegistry &registry)
 {
     if (enum_name.empty()) {
         return nonstd::make_unexpected(std::format("Argument '{}' is a soft enum without a name.", name));
     }
-    const auto index = findOrCreateSoftEnum(enum_name, registry);
+    const auto enum_index = findOrCreateSoftEnum(enum_name, registry);
 
-    auto data = basicParameter(name, command);
+    auto data = basicParameter(name, index, command);
     data.param_type = CommandParameterDataType::SoftEnum;
-    data.enum_name_or_postfix = registry.soft_enums_.at(index).name.c_str();
-    data.enum_or_postfix_symbol = CommandRegistry::Symbol::fromSoftEnumIndex(index).value();
+    data.enum_name_or_postfix = registry.soft_enums_.at(enum_index).name.c_str();
+    data.enum_or_postfix_symbol = CommandRegistry::Symbol::fromSoftEnumIndex(enum_index).value();
     return data;
 }
 
 nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::hardNonTerminalParameter(
-    const std::string &name, CommandRegistry::HardNonTerminal symbol, TreeCommand &command)
+    const std::string &name, CommandRegistry::HardNonTerminal symbol, int index, TreeCommand &command)
 {
-    auto data = basicParameter(name, command);
+    auto data = basicParameter(name, index, command);
     data.chained_subcommand_symbol = static_cast<int>(symbol);
     return data;
 }
 
 nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::makeLiteralParameter(
-    const std::string &literal, TreeCommand &command, CommandRegistry &registry)
+    const std::string &literal, int index, TreeCommand &command, CommandRegistry &registry)
 {
-    return newEnumParameter(literal, literal, {literal}, command, registry);
+    return newEnumParameter(literal, literal, {literal}, index, command, registry);
 }
 
 nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::makeArgumentParameter(
-    const std::string &name, const ArgumentType &type, TreeCommand &command, CommandRegistry &registry)
+    const std::string &name, const ArgumentType &type, int index, TreeCommand &command, CommandRegistry &registry)
 {
     using HardNonTerminal = CommandRegistry::HardNonTerminal;
 
     switch (type.getKind()) {
     case ArgumentKind::Boolean:
-        return existingEnumParameter(name, "Boolean", command, registry);
+        return existingEnumParameter(name, "Boolean", index, command, registry);
     case ArgumentKind::BlockType:
-        return existingEnumParameter(name, "Block", command, registry);
+        return existingEnumParameter(name, "Block", index, command, registry);
     case ArgumentKind::EntityType:
-        return existingEnumParameter(name, "EntityType", command, registry);
+        return existingEnumParameter(name, "EntityType", index, command, registry);
     case ArgumentKind::Integer:
-        return hardNonTerminalParameter(name, HardNonTerminal::Int, command);
+        return hardNonTerminalParameter(name, HardNonTerminal::Int, index, command);
     case ArgumentKind::Float:
-        return hardNonTerminalParameter(name, HardNonTerminal::Val, command);
+        return hardNonTerminalParameter(name, HardNonTerminal::Val, index, command);
     case ArgumentKind::String:
-        return hardNonTerminalParameter(name, HardNonTerminal::Id, command);
+        return hardNonTerminalParameter(name, HardNonTerminal::Id, index, command);
     case ArgumentKind::Message:
-        return hardNonTerminalParameter(name, HardNonTerminal::MessageRoot, command);
+        return hardNonTerminalParameter(name, HardNonTerminal::MessageRoot, index, command);
     case ArgumentKind::RawText:
-        return hardNonTerminalParameter(name, HardNonTerminal::RawText, command);
+        return hardNonTerminalParameter(name, HardNonTerminal::RawText, index, command);
     case ArgumentKind::Json:
-        return hardNonTerminalParameter(name, HardNonTerminal::JsonObject, command);
+        return hardNonTerminalParameter(name, HardNonTerminal::JsonObject, index, command);
     case ArgumentKind::Enumeration: {
         const auto &builtin = static_cast<const BuiltinArgumentType &>(type);
-        return newEnumParameter(name, builtin.getName(), builtin.getValues(), command, registry);
+        return newEnumParameter(name, builtin.getName(), builtin.getValues(), index, command, registry);
     }
     case ArgumentKind::SoftEnum: {
         const auto &builtin = static_cast<const BuiltinArgumentType &>(type);
-        return softEnumParameter(name, builtin.getName(), command, registry);
+        return softEnumParameter(name, builtin.getName(), index, command, registry);
     }
     case ArgumentKind::Custom: {
         const auto native = type.getNativeType();
@@ -155,7 +158,7 @@ nonstd::expected<CommandParameterData, std::string> CommandTreeRegistrar::makeAr
             return nonstd::make_unexpected(std::format(
                 "Argument '{}' is a custom type but does not name a native type to be presented as.", name));
         }
-        return makeArgumentParameter(name, *native, command, registry);
+        return makeArgumentParameter(name, *native, index, command, registry);
     }
     default:
         return nonstd::make_unexpected(std::format("Argument '{}' uses a type that is not supported yet.", name));

--- a/src/endstone/core/command/tree/command_tree_registrar.h
+++ b/src/endstone/core/command/tree/command_tree_registrar.h
@@ -39,7 +39,7 @@ public:
      * A literal becomes a single-value enum, which is what the client renders as the word to type.
      */
     static nonstd::expected<CommandParameterData, std::string> makeLiteralParameter(const std::string &literal,
-                                                                                    TreeCommand &command,
+                                                                                    int index, TreeCommand &command,
                                                                                     CommandRegistry &registry);
 
     /**
@@ -49,7 +49,7 @@ public:
      */
     static nonstd::expected<CommandParameterData, std::string> makeArgumentParameter(const std::string &name,
                                                                                      const ArgumentType &type,
-                                                                                     TreeCommand &command,
+                                                                                     int index, TreeCommand &command,
                                                                                      CommandRegistry &registry);
 
     /**
@@ -60,22 +60,22 @@ public:
     static bool setSoftEnumValues(const std::string &name, std::vector<std::string> values, CommandRegistry &registry);
 
 private:
-    static CommandParameterData basicParameter(const std::string &name, TreeCommand &command);
+    static CommandParameterData basicParameter(const std::string &name, int index, TreeCommand &command);
     static nonstd::expected<CommandParameterData, std::string> existingEnumParameter(const std::string &name,
-                                                                                     const char *enum_name,
+                                                                                     const char *enum_name, int index,
                                                                                      TreeCommand &command,
                                                                                      CommandRegistry &registry);
     static nonstd::expected<CommandParameterData, std::string> newEnumParameter(const std::string &name,
                                                                                 const std::string &wanted_enum_name,
                                                                                 const std::vector<std::string> &values,
-                                                                                TreeCommand &command,
+                                                                                int index, TreeCommand &command,
                                                                                 CommandRegistry &registry);
     static nonstd::expected<CommandParameterData, std::string> softEnumParameter(const std::string &name,
                                                                                  const std::string &enum_name,
-                                                                                 TreeCommand &command,
+                                                                                 int index, TreeCommand &command,
                                                                                  CommandRegistry &registry);
     static nonstd::expected<CommandParameterData, std::string> hardNonTerminalParameter(
-        const std::string &name, CommandRegistry::HardNonTerminal symbol, TreeCommand &command);
+        const std::string &name, CommandRegistry::HardNonTerminal symbol, int index, TreeCommand &command);
     static std::uint32_t findOrCreateSoftEnum(const std::string &name, CommandRegistry &registry);
     static std::string uniqueEnumName(const std::string &wanted, const CommandRegistry &registry);
 };

--- a/src/endstone/core/command/tree/command_tree_registrar.h
+++ b/src/endstone/core/command/tree/command_tree_registrar.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <nonstd/expected.hpp>
+
+#include "bedrock/server/commands/command_registry.h"
+#include "endstone/command/argument_type.h"
+
+namespace endstone::core {
+
+class TreeCommand;
+
+/**
+ * Turns command tree nodes into the parameters the command registry accepts.
+ *
+ * Reaches into the registry's enum tables, which is why it is a friend of CommandRegistry.
+ */
+class CommandTreeRegistrar {
+public:
+    /**
+     * Builds the parameter a literal node is registered as.
+     *
+     * A literal becomes a single-value enum, which is what the client renders as the word to type.
+     */
+    static nonstd::expected<CommandParameterData, std::string> makeLiteralParameter(const std::string &literal,
+                                                                                    TreeCommand &command,
+                                                                                    CommandRegistry &registry);
+
+    /**
+     * Builds the parameter an argument node is registered as.
+     *
+     * Returns an error message for an argument type that cannot yet be registered.
+     */
+    static nonstd::expected<CommandParameterData, std::string> makeArgumentParameter(const std::string &name,
+                                                                                     const ArgumentType &type,
+                                                                                     TreeCommand &command,
+                                                                                     CommandRegistry &registry);
+
+    /**
+     * Replaces the values of a soft enum, creating it if it does not exist yet.
+     *
+     * @return true if the values were pushed to connected clients
+     */
+    static bool setSoftEnumValues(const std::string &name, std::vector<std::string> values, CommandRegistry &registry);
+
+private:
+    static CommandParameterData basicParameter(const std::string &name, TreeCommand &command);
+    static nonstd::expected<CommandParameterData, std::string> existingEnumParameter(const std::string &name,
+                                                                                     const char *enum_name,
+                                                                                     TreeCommand &command,
+                                                                                     CommandRegistry &registry);
+    static nonstd::expected<CommandParameterData, std::string> newEnumParameter(const std::string &name,
+                                                                                const std::string &wanted_enum_name,
+                                                                                const std::vector<std::string> &values,
+                                                                                TreeCommand &command,
+                                                                                CommandRegistry &registry);
+    static nonstd::expected<CommandParameterData, std::string> softEnumParameter(const std::string &name,
+                                                                                 const std::string &enum_name,
+                                                                                 TreeCommand &command,
+                                                                                 CommandRegistry &registry);
+    static nonstd::expected<CommandParameterData, std::string> hardNonTerminalParameter(
+        const std::string &name, CommandRegistry::HardNonTerminal symbol, TreeCommand &command);
+    static std::uint32_t findOrCreateSoftEnum(const std::string &name, CommandRegistry &registry);
+    static std::string uniqueEnumName(const std::string &wanted, const CommandRegistry &registry);
+};
+
+}  // namespace endstone::core

--- a/src/endstone/core/command/tree/tree_command.cpp
+++ b/src/endstone/core/command/tree/tree_command.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "endstone/core/command/tree/tree_command.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "endstone/command/command_context.h"
+#include "endstone/command/command_error.h"
+#include "endstone/core/command/parse_token_text.h"
+#include "endstone/core/command/tree/argument_types.h"
+#include "endstone/core/server.h"
+
+namespace endstone::core {
+
+namespace {
+
+class TreeCommandContext : public CommandContext {
+public:
+    TreeCommandContext(const Command &command, NotNull<CommandSender> sender, std::string input)
+        : command_(command), sender_(std::move(sender)), input_(std::move(input))
+    {
+    }
+
+    [[nodiscard]] const NotNull<CommandSender> &getSender() const override { return sender_; }
+    [[nodiscard]] const Command &getCommand() const override { return command_; }
+    [[nodiscard]] std::string getInput() const override { return input_; }
+
+    [[nodiscard]] std::vector<std::string> getArgumentNames() const override
+    {
+        std::vector<std::string> names;
+        names.reserve(order_.size());
+        for (const auto &name : order_) {
+            names.push_back(name);
+        }
+        return names;
+    }
+
+    [[nodiscard]] const ArgumentValue *find(std::string_view name) const override
+    {
+        const auto it = values_.find(std::string(name));
+        return it == values_.end() ? nullptr : &it->second;
+    }
+
+    void bind(const std::string &name, ArgumentValue value)
+    {
+        if (!values_.contains(name)) {
+            order_.push_back(name);
+        }
+        values_.insert_or_assign(name, std::move(value));
+    }
+
+private:
+    const Command &command_;
+    NotNull<CommandSender> sender_;
+    std::string input_;
+    std::vector<std::string> order_;
+    std::unordered_map<std::string, ArgumentValue> values_;
+};
+
+}  // namespace
+
+TreeCommand::TreeCommand(NotNull<LiteralCommandNode> root, std::vector<CommandTreeOverload> overloads)
+    : Command(root->getName(), root->getDescription()), root_(std::move(root)), overloads_(std::move(overloads))
+{
+    setAliases(root_->getAliases());
+    setPermissions(root_->getPermissions());
+}
+
+const char *TreeCommand::intern(const std::string &name)
+{
+    interned_.push_back(name);
+    return interned_.back().c_str();
+}
+
+bool TreeCommand::testOverloadSilently(const CommandTreeOverload &overload, const NotNull<CommandSender> &sender)
+{
+    return std::ranges::all_of(overload.path, [&sender](const auto &node) { return node->testSilently(sender); });
+}
+
+bool TreeCommand::execute(const NotNull<CommandSender> &sender, const std::vector<std::string> & /*args*/) const
+{
+    sender->sendErrorMessage(Translatable("commands.generic.unknown", {getName()}));
+    return false;
+}
+
+bool TreeCommand::run(const CommandTreeOverload &overload, const NotNull<CommandSender> &sender,
+                      const std::vector<std::string> &values, const std::string &input) const
+{
+    if (!testOverloadSilently(overload, sender)) {
+        sender->sendErrorMessage(Translatable("commands.generic.error.permissions", {getName()}));
+        return false;
+    }
+
+    TreeCommandContext context(*this, sender, input);
+    for (std::size_t i = 0; i < overload.slots.size() && i < values.size(); ++i) {
+        const auto &slot = overload.slots[i];
+        if (slot.is_literal) {
+            continue;
+        }
+        const auto *argument = static_cast<const ArgumentCommandNode *>(slot.node.get().get());
+        context.bind(argument->getName(), convertArgument(*argument->getArgumentType(), values[i], sender));
+    }
+
+    overload.leaf->getHandler()(context);
+    return true;
+}
+
+bool TreeCommandAdapter::runFrom(const NotNull<CommandSender> &sender) const
+{
+    try {
+        return command_->run(*overload_, sender, args_, input_);
+    }
+    catch (const CommandError &e) {
+        sender->sendErrorMessage(e.getMessage());
+        return false;
+    }
+    catch (const std::exception &e) {
+        EndstoneServer::getInstance().getLogger().error("Unhandled exception executing '{}': {}", command_->getName(),
+                                                        e.what());
+        return false;
+    }
+}
+
+void TreeCommandAdapter::execute(const CommandOrigin &origin, CommandOutput &output) const
+{
+    if (runFrom(origin.getEndstoneSender(output))) {
+        output.success();
+    }
+}
+
+}  // namespace endstone::core
+
+template <>
+bool CommandRegistry::parse<endstone::core::TreeCommandAdapter>(void *storage, const ParseToken &token,
+                                                                const CommandOrigin &origin, int version,
+                                                                std::string &error,
+                                                                std::vector<std::string> &error_params) const
+{
+    if (!storage) {
+        return false;
+    }
+    auto *adapter = static_cast<endstone::core::TreeCommandAdapter *>(storage);
+    if (adapter->input_.empty()) {
+        const auto *root = &token;
+        while (root->parent) {
+            root = root->parent;
+        }
+        if (root->text && root->length > 0) {
+            adapter->input_.assign(root->text, root->length);
+        }
+    }
+    if (auto result = endstone::core::parseNode(token)) {
+        adapter->args_.emplace_back(*result);
+    }
+    else {
+        adapter->args_.emplace_back();
+    }
+    return true;
+}
+
+template <>
+const CommandRegistry::ParamParseRule CommandRegistry::ParseRuleFor<endstone::core::TreeCommandAdapter>::instance{
+    &CommandRegistry::parse<endstone::core::TreeCommandAdapter>, {}};

--- a/src/endstone/core/command/tree/tree_command.cpp
+++ b/src/endstone/core/command/tree/tree_command.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <unordered_map>
 
+#include "bedrock/server/commands/command_selector.h"
 #include "endstone/command/command_context.h"
 #include "endstone/command/command_error.h"
 #include "endstone/core/command/parse_token_text.h"
@@ -68,6 +69,24 @@ private:
     std::unordered_map<std::string, ArgumentValue> values_;
 };
 
+std::unique_ptr<ArgumentStorage> makeStorage(const CommandTreeSlot &slot)
+{
+    if (!slot.is_literal) {
+        const auto &type = *static_cast<const ArgumentCommandNode *>(slot.node.get().get())->getArgumentType();
+        switch (effectiveArgumentKind(type)) {
+        case ArgumentKind::Player:
+        case ArgumentKind::Players:
+            return std::make_unique<TypedArgumentStorage<CommandSelector<::Player>>>();
+        case ArgumentKind::Entity:
+        case ArgumentKind::Entities:
+            return std::make_unique<TypedArgumentStorage<CommandSelector<::Actor>>>();
+        default:
+            break;
+        }
+    }
+    return std::make_unique<TypedArgumentStorage<std::string>>();
+}
+
 }  // namespace
 
 TreeCommand::TreeCommand(NotNull<LiteralCommandNode> root, std::vector<CommandTreeOverload> overloads)
@@ -95,7 +114,7 @@ bool TreeCommand::execute(const NotNull<CommandSender> &sender, const std::vecto
 }
 
 bool TreeCommand::run(const CommandTreeOverload &overload, const NotNull<CommandSender> &sender,
-                      const std::vector<std::unique_ptr<ArgumentStorage>> &slots) const
+                      const std::vector<std::unique_ptr<ArgumentStorage>> &slots, const CommandOrigin &origin) const
 {
     if (!testOverloadSilently(overload, sender)) {
         sender->sendErrorMessage(Translatable("commands.generic.error.permissions", {getName()}));
@@ -109,8 +128,24 @@ bool TreeCommand::run(const CommandTreeOverload &overload, const NotNull<Command
             continue;
         }
         const auto *argument = static_cast<const ArgumentCommandNode *>(slot.node.get().get());
+        const auto &type = *argument->getArgumentType();
+        const auto kind = effectiveArgumentKind(type);
+
+        if (isSelectorArgument(kind)) {
+            const auto results =
+                kind == ArgumentKind::Player || kind == ArgumentKind::Players
+                    ? static_cast<const TypedArgumentStorage<CommandSelector<::Player>> *>(slots[i].get())
+                          ->get()
+                          .newResults(origin)
+                    : static_cast<const TypedArgumentStorage<CommandSelector<::Actor>> *>(slots[i].get())
+                          ->get()
+                          .newResults(origin);
+            context.bind(argument->getName(), convertSelector(type, results, sender));
+            continue;
+        }
+
         const auto *text = static_cast<const TypedArgumentStorage<std::string> *>(slots[i].get());
-        context.bind(argument->getName(), convertArgument(*argument->getArgumentType(), text->get(), sender));
+        context.bind(argument->getName(), convertArgument(type, text->get(), sender));
     }
 
     overload.leaf->getHandler()(context);
@@ -121,8 +156,8 @@ TreeCommandAdapter::TreeCommandAdapter(const TreeCommand &command, const Command
     : command_(&command), overload_(&overload)
 {
     slots_.reserve(overload.slots.size());
-    for (std::size_t i = 0; i < overload.slots.size(); ++i) {
-        slots_.push_back(std::make_unique<TypedArgumentStorage<std::string>>());
+    for (const auto &slot : overload.slots) {
+        slots_.push_back(makeStorage(slot));
     }
 }
 
@@ -135,10 +170,10 @@ void *TreeCommandAdapter::getStorageValue(::Command *command, int index)
     return slots[index]->data();
 }
 
-bool TreeCommandAdapter::runFrom(const NotNull<CommandSender> &sender) const
+bool TreeCommandAdapter::runFrom(const NotNull<CommandSender> &sender, const CommandOrigin &origin) const
 {
     try {
-        return command_->run(*overload_, sender, slots_);
+        return command_->run(*overload_, sender, slots_, origin);
     }
     catch (const CommandError &e) {
         sender->sendErrorMessage(e.getMessage());
@@ -153,7 +188,7 @@ bool TreeCommandAdapter::runFrom(const NotNull<CommandSender> &sender) const
 
 void TreeCommandAdapter::execute(const CommandOrigin &origin, CommandOutput &output) const
 {
-    if (runFrom(origin.getEndstoneSender(output))) {
+    if (runFrom(origin.getEndstoneSender(output), origin)) {
         output.success();
     }
 }

--- a/src/endstone/core/command/tree/tree_command.cpp
+++ b/src/endstone/core/command/tree/tree_command.cpp
@@ -29,14 +29,13 @@ namespace {
 
 class TreeCommandContext : public CommandContext {
 public:
-    TreeCommandContext(const Command &command, NotNull<CommandSender> sender, std::string input)
-        : command_(command), sender_(std::move(sender)), input_(std::move(input))
+    TreeCommandContext(const Command &command, NotNull<CommandSender> sender)
+        : command_(command), sender_(std::move(sender))
     {
     }
 
     [[nodiscard]] const NotNull<CommandSender> &getSender() const override { return sender_; }
     [[nodiscard]] const Command &getCommand() const override { return command_; }
-    [[nodiscard]] std::string getInput() const override { return input_; }
 
     [[nodiscard]] std::vector<std::string> getArgumentNames() const override
     {
@@ -65,7 +64,6 @@ public:
 private:
     const Command &command_;
     NotNull<CommandSender> sender_;
-    std::string input_;
     std::vector<std::string> order_;
     std::unordered_map<std::string, ArgumentValue> values_;
 };
@@ -97,31 +95,50 @@ bool TreeCommand::execute(const NotNull<CommandSender> &sender, const std::vecto
 }
 
 bool TreeCommand::run(const CommandTreeOverload &overload, const NotNull<CommandSender> &sender,
-                      const std::vector<std::string> &values, const std::string &input) const
+                      const std::vector<std::unique_ptr<ArgumentStorage>> &slots) const
 {
     if (!testOverloadSilently(overload, sender)) {
         sender->sendErrorMessage(Translatable("commands.generic.error.permissions", {getName()}));
         return false;
     }
 
-    TreeCommandContext context(*this, sender, input);
-    for (std::size_t i = 0; i < overload.slots.size() && i < values.size(); ++i) {
+    TreeCommandContext context(*this, sender);
+    for (std::size_t i = 0; i < overload.slots.size() && i < slots.size(); ++i) {
         const auto &slot = overload.slots[i];
         if (slot.is_literal) {
             continue;
         }
         const auto *argument = static_cast<const ArgumentCommandNode *>(slot.node.get().get());
-        context.bind(argument->getName(), convertArgument(*argument->getArgumentType(), values[i], sender));
+        const auto *text = static_cast<const TypedArgumentStorage<std::string> *>(slots[i].get());
+        context.bind(argument->getName(), convertArgument(*argument->getArgumentType(), text->get(), sender));
     }
 
     overload.leaf->getHandler()(context);
     return true;
 }
 
+TreeCommandAdapter::TreeCommandAdapter(const TreeCommand &command, const CommandTreeOverload &overload)
+    : command_(&command), overload_(&overload)
+{
+    slots_.reserve(overload.slots.size());
+    for (std::size_t i = 0; i < overload.slots.size(); ++i) {
+        slots_.push_back(std::make_unique<TypedArgumentStorage<std::string>>());
+    }
+}
+
+void *TreeCommandAdapter::getStorageValue(::Command *command, int index)
+{
+    auto &slots = static_cast<TreeCommandAdapter *>(command)->slots_;
+    if (index < 0 || static_cast<std::size_t>(index) >= slots.size()) {
+        return nullptr;
+    }
+    return slots[index]->data();
+}
+
 bool TreeCommandAdapter::runFrom(const NotNull<CommandSender> &sender) const
 {
     try {
-        return command_->run(*overload_, sender, args_, input_);
+        return command_->run(*overload_, sender, slots_);
     }
     catch (const CommandError &e) {
         sender->sendErrorMessage(e.getMessage());
@@ -152,21 +169,8 @@ bool CommandRegistry::parse<endstone::core::TreeCommandAdapter>(void *storage, c
     if (!storage) {
         return false;
     }
-    auto *adapter = static_cast<endstone::core::TreeCommandAdapter *>(storage);
-    if (adapter->input_.empty()) {
-        const auto *root = &token;
-        while (root->parent) {
-            root = root->parent;
-        }
-        if (root->text && root->length > 0) {
-            adapter->input_.assign(root->text, root->length);
-        }
-    }
     if (auto result = endstone::core::parseNode(token)) {
-        adapter->args_.emplace_back(*result);
-    }
-    else {
-        adapter->args_.emplace_back();
+        static_cast<std::string *>(storage)->assign(*result);
     }
     return true;
 }

--- a/src/endstone/core/command/tree/tree_command.h
+++ b/src/endstone/core/command/tree/tree_command.h
@@ -75,10 +75,12 @@ public:
      * @param overload the overload that parsed
      * @param sender source of the command
      * @param slots the parsed value of each slot, in slot order
+     * @param origin the origin the command registry parsed against, needed to resolve selectors
      * @return true if the command reported success
      */
     [[nodiscard]] bool run(const CommandTreeOverload &overload, const NotNull<CommandSender> &sender,
-                           const std::vector<std::unique_ptr<ArgumentStorage>> &slots) const;
+                           const std::vector<std::unique_ptr<ArgumentStorage>> &slots,
+                           const CommandOrigin &origin) const;
 
     /**
      * Tests every node on an overload's path against a sender.
@@ -121,9 +123,10 @@ public:
      * the command registry run it.
      *
      * @param sender source of the command
+     * @param origin the origin the command line was compiled against
      * @return true if the command reported success
      */
-    [[nodiscard]] bool runFrom(const NotNull<CommandSender> &sender) const;
+    [[nodiscard]] bool runFrom(const NotNull<CommandSender> &sender, const CommandOrigin &origin) const;
 
 private:
     friend class ::CommandRegistry;

--- a/src/endstone/core/command/tree/tree_command.h
+++ b/src/endstone/core/command/tree/tree_command.h
@@ -30,6 +30,30 @@ namespace endstone::core {
 class TreeCommandAdapter;
 
 /**
+ * Type-erased storage for one parsed parameter.
+ *
+ * A command tree is shaped at runtime, so its parameters cannot live at fixed offsets in a struct
+ * the way a vanilla command's do. The command registry supports exactly this through
+ * CommandParameterData's custom storage accessors, which is how Mojang's own script command layer
+ * works.
+ */
+class ArgumentStorage {
+public:
+    virtual ~ArgumentStorage() = default;
+    [[nodiscard]] virtual void *data() = 0;
+};
+
+template <typename T>
+class TypedArgumentStorage : public ArgumentStorage {
+public:
+    [[nodiscard]] void *data() override { return &value_; }
+    [[nodiscard]] const T &get() const { return value_; }
+
+private:
+    T value_{};
+};
+
+/**
  * The Command a registered command tree is exposed as.
  *
  * Owns the tree, the flattened overloads the adapters point back into, and the enum name strings
@@ -50,12 +74,11 @@ public:
      *
      * @param overload the overload that parsed
      * @param sender source of the command
-     * @param values the parsed text of each slot, in slot order
-     * @param input the command line as typed
+     * @param slots the parsed value of each slot, in slot order
      * @return true if the command reported success
      */
     [[nodiscard]] bool run(const CommandTreeOverload &overload, const NotNull<CommandSender> &sender,
-                           const std::vector<std::string> &values, const std::string &input) const;
+                           const std::vector<std::unique_ptr<ArgumentStorage>> &slots) const;
 
     /**
      * Tests every node on an overload's path against a sender.
@@ -84,10 +107,10 @@ private:
  */
 class TreeCommandAdapter : public ::Command {
 public:
-    TreeCommandAdapter(const TreeCommand &command, const CommandTreeOverload &overload)
-        : command_(&command), overload_(&overload)
-    {
-    }
+    TreeCommandAdapter(const TreeCommand &command, const CommandTreeOverload &overload);
+
+    /** Hands the command registry the storage for one parameter. */
+    static void *getStorageValue(::Command *command, int index);
 
     void execute(const CommandOrigin &origin, CommandOutput &output) const override;
 
@@ -107,8 +130,7 @@ private:
 
     const TreeCommand *command_;
     const CommandTreeOverload *overload_;
-    std::vector<std::string> args_;
-    std::string input_;
+    std::vector<std::unique_ptr<ArgumentStorage>> slots_;
 };
 
 }  // namespace endstone::core

--- a/src/endstone/core/command/tree/tree_command.h
+++ b/src/endstone/core/command/tree/tree_command.h
@@ -1,0 +1,117 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "bedrock/server/commands/command.h"
+#include "bedrock/server/commands/command_registry.h"
+#include "endstone/command/command.h"
+#include "endstone/command/command_node.h"
+#include "endstone/core/command/tree/command_tree.h"
+
+namespace endstone::core {
+
+class TreeCommandAdapter;
+
+/**
+ * The Command a registered command tree is exposed as.
+ *
+ * Owns the tree, the flattened overloads the adapters point back into, and the enum name strings
+ * the command registry borrows.
+ */
+class TreeCommand : public Command {
+public:
+    TreeCommand(NotNull<LiteralCommandNode> root, std::vector<CommandTreeOverload> overloads);
+
+    [[nodiscard]] bool execute(const NotNull<CommandSender> &sender,
+                               const std::vector<std::string> &args) const override;
+
+    [[nodiscard]] const NotNull<LiteralCommandNode> &getRoot() const { return root_; }
+    [[nodiscard]] const std::vector<CommandTreeOverload> &getOverloads() const { return overloads_; }
+
+    /**
+     * Runs the branch an adapter matched.
+     *
+     * @param overload the overload that parsed
+     * @param sender source of the command
+     * @param values the parsed text of each slot, in slot order
+     * @param input the command line as typed
+     * @return true if the command reported success
+     */
+    [[nodiscard]] bool run(const CommandTreeOverload &overload, const NotNull<CommandSender> &sender,
+                           const std::vector<std::string> &values, const std::string &input) const;
+
+    /**
+     * Tests every node on an overload's path against a sender.
+     *
+     * @param overload the overload to test
+     * @param sender the sender to test
+     * @return true if the sender may use the whole branch
+     */
+    [[nodiscard]] static bool testOverloadSilently(const CommandTreeOverload &overload,
+                                                   const NotNull<CommandSender> &sender);
+
+    /** Keeps an enum name alive for as long as the command registry borrows it. */
+    const char *intern(const std::string &name);
+
+private:
+    NotNull<LiteralCommandNode> root_;
+    std::vector<CommandTreeOverload> overloads_;
+    std::deque<std::string> interned_;
+};
+
+/**
+ * The bedrock Command a flattened overload allocates.
+ *
+ * Each overload binds its own adapter through a capturing allocator, so an adapter always knows
+ * which branch of the tree parsed.
+ */
+class TreeCommandAdapter : public ::Command {
+public:
+    TreeCommandAdapter(const TreeCommand &command, const CommandTreeOverload &overload)
+        : command_(&command), overload_(&overload)
+    {
+    }
+
+    void execute(const CommandOrigin &origin, CommandOutput &output) const override;
+
+    /**
+     * Runs the branch this adapter parsed against a sender directly.
+     *
+     * Used by CommandMap::dispatch, which compiles the command line itself rather than letting
+     * the command registry run it.
+     *
+     * @param sender source of the command
+     * @return true if the command reported success
+     */
+    [[nodiscard]] bool runFrom(const NotNull<CommandSender> &sender) const;
+
+private:
+    friend class ::CommandRegistry;
+
+    const TreeCommand *command_;
+    const CommandTreeOverload *overload_;
+    std::vector<std::string> args_;
+    std::string input_;
+};
+
+}  // namespace endstone::core
+
+template <>
+const CommandRegistry::ParamParseRule CommandRegistry::ParseRuleFor<endstone::core::TreeCommandAdapter>::instance;

--- a/src/endstone/core/player.cpp
+++ b/src/endstone/core/player.cpp
@@ -41,6 +41,7 @@
 #include "bedrock/world/level/level.h"
 #include "endstone/color_format.h"
 #include "endstone/core/base64.h"
+#include "endstone/core/command/tree/tree_command.h"
 #include "endstone/core/entity/components/flag_components.h"
 #include "endstone/core/form/form_codec.h"
 #include "endstone/core/game_mode.h"
@@ -570,6 +571,25 @@ std::string EndstonePlayer::getLocale() const
     return locale_;
 }
 
+namespace {
+bool retainVisibleOverloads(const Nullable<Command> &command, AvailableCommandsPacketPayload::CommandData &data,
+                            const NotNull<CommandSender> &sender)
+{
+    const auto tree = std::dynamic_pointer_cast<TreeCommand>(command.get());
+    if (!tree) {
+        return true;
+    }
+
+    const auto &overloads = tree->getOverloads();
+    for (auto i = data.overloads.size(); i-- > 0;) {
+        if (i >= overloads.size() || !TreeCommand::testOverloadSilently(overloads[i], sender)) {
+            data.overloads.erase(data.overloads.begin() + static_cast<std::ptrdiff_t>(i));
+        }
+    }
+    return !data.overloads.empty();
+}
+}  // namespace
+
 void EndstonePlayer::updateCommands() const
 {
     const auto &command_map = server_.getCommandMap();
@@ -580,7 +600,8 @@ void EndstonePlayer::updateCommands() const
     for (auto it = packet.payload.commands.begin(); it != packet.payload.commands.end();) {
         const auto &name = it->name;
         const auto command = command_map.getCommand(name);
-        if (command && command->isRegistered() && command->testPermissionSilently(self())) {
+        if (command && command->isRegistered() && command->testPermissionSilently(self()) &&
+            retainVisibleOverloads(command, *it, self())) {
             if (auto symbol = registry.findEnumValue(name); symbol.value() != 0) {
                 auto symbol_index = static_cast<std::uint32_t>(symbol.toIndex());
                 if (it->permission_level >= CommandPermissionLevel::Host) {

--- a/src/endstone/python/CMakeLists.txt
+++ b/src/endstone/python/CMakeLists.txt
@@ -11,6 +11,7 @@ pybind11_add_module(_python MODULE
         block.cpp
         boss.cpp
         command.cpp
+        command_tree.cpp
         damage.cpp
         enchantments.cpp
         endstone_python.cpp

--- a/src/endstone/python/command_tree.cpp
+++ b/src/endstone/python/command_tree.cpp
@@ -1,0 +1,272 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "endstone/command/arguments.h"
+#include "endstone/command/command_builder.h"
+#include "endstone/command/command_context.h"
+#include "endstone/command/command_error.h"
+#include "endstone/command/command_node.h"
+#include "endstone_python.h"
+
+namespace endstone::python {
+
+namespace {
+
+py::handle command_error_type;
+
+py::object toPython(const ArgumentValue &value)
+{
+    if (const auto *v = value.get<bool>()) {
+        return py::cast(*v);
+    }
+    if (const auto *v = value.get<int>()) {
+        return py::cast(*v);
+    }
+    if (const auto *v = value.get<float>()) {
+        return py::cast(*v);
+    }
+    if (const auto *v = value.get<std::string>()) {
+        return py::cast(*v);
+    }
+    if (const auto *v = value.get<NotNull<Player>>()) {
+        return py::cast(*v);
+    }
+    if (const auto *v = value.get<std::vector<NotNull<Player>>>()) {
+        return py::cast(*v);
+    }
+    if (const auto *v = value.get<NotNull<Actor>>()) {
+        return py::cast(*v);
+    }
+    if (const auto *v = value.get<std::vector<NotNull<Actor>>>()) {
+        return py::cast(*v);
+    }
+    throw py::type_error(std::format("Argument of type '{}' cannot be read from Python.", value.getTypeName()));
+}
+
+CommandHandler wrapHandler(py::function handler)
+{
+    return [handler = std::move(handler)](const CommandContext &ctx) {
+        const py::gil_scoped_acquire gil{};
+        try {
+            handler(py::cast(&ctx, py::return_value_policy::reference));
+        }
+        catch (py::error_already_set &e) {
+            if (command_error_type && e.matches(command_error_type)) {
+                throw CommandError(py::str(e.value()).cast<std::string>());
+            }
+            throw;
+        }
+    };
+}
+
+CommandRequirement wrapRequirement(py::function predicate)
+{
+    return [predicate = std::move(predicate)](const NotNull<CommandSender> &sender) {
+        const py::gil_scoped_acquire gil{};
+        return predicate(sender).cast<bool>();
+    };
+}
+
+template <typename Builder>
+void bindBuilder(py::class_<Builder> &cls)
+{
+    cls.def(
+           "then", [](Builder &self, const LiteralArgumentBuilder &child) { return self.then(child.build()); },
+           py::arg("child"), "Adds a child branch.")
+        .def(
+            "then", [](Builder &self, const RequiredArgumentBuilder &child) { return self.then(child.build()); },
+            py::arg("child"), "Adds a child branch.")
+        .def(
+            "executes", [](Builder &self, py::function handler) { return self.executes(wrapHandler(std::move(handler))); },
+            py::arg("handler"), R"doc(
+    Sets the handler run when a command ends at this node.
+
+    Returning normally reports the command as successful; raise a `CommandError` to report a
+    failure to the sender.
+)doc")
+        .def(
+            "permission", [](Builder &self, std::string permission) { return self.permission(std::move(permission)); },
+            py::arg("permission"), R"doc(
+    Requires a permission to use this branch.
+
+    A sender holding any one of the permissions added here passes. A sender without one is told
+    they lack permission, and the branch is hidden from their client.
+)doc")
+        .def(
+            "requires",
+            [](Builder &self, py::function predicate) { return self.requires_(wrapRequirement(std::move(predicate))); },
+            py::arg("predicate"), R"doc(
+    Requires a predicate to pass to use this branch.
+
+    Unlike `permission`, a sender that fails is not told why, and the branch is simply absent.
+    Keep the predicate cheap: it runs once per node per parse, and again for every node each time
+    the command tree is sent to a player.
+)doc")
+        .def("build", &Builder::build, "Returns the node this builder has shaped.");
+}
+
+}  // namespace
+
+void init_command_tree(py::module_ &m)
+{
+    command_error_type = py::register_exception<CommandError>(m, "CommandError").ptr();
+
+    py::enum_<ArgumentKind>(m, "ArgumentKind", "The built-in argument types Endstone can register with the client.")
+        .value("CUSTOM", ArgumentKind::Custom)
+        .value("BOOLEAN", ArgumentKind::Boolean)
+        .value("INTEGER", ArgumentKind::Integer)
+        .value("FLOAT", ArgumentKind::Float)
+        .value("STRING", ArgumentKind::String)
+        .value("MESSAGE", ArgumentKind::Message)
+        .value("RAW_TEXT", ArgumentKind::RawText)
+        .value("PLAYER", ArgumentKind::Player)
+        .value("PLAYERS", ArgumentKind::Players)
+        .value("ENTITY", ArgumentKind::Entity)
+        .value("ENTITIES", ArgumentKind::Entities)
+        .value("BLOCK_POSITION", ArgumentKind::BlockPosition)
+        .value("POSITION", ArgumentKind::Position)
+        .value("BLOCK_TYPE", ArgumentKind::BlockType)
+        .value("BLOCK_STATES", ArgumentKind::BlockStates)
+        .value("ENTITY_TYPE", ArgumentKind::EntityType)
+        .value("JSON", ArgumentKind::Json)
+        .value("INTEGER_RANGE", ArgumentKind::IntegerRange)
+        .value("ENUMERATION", ArgumentKind::Enumeration)
+        .value("SOFT_ENUM", ArgumentKind::SoftEnum);
+
+    py::classh<ArgumentType>(m, "ArgumentType", "Describes how a command argument is parsed.")
+        .def_property_readonly("kind", &ArgumentType::getKind, "Which built-in type this is.");
+
+    py::classh<BuiltinArgumentType, ArgumentType>(m, "BuiltinArgumentType",
+                                                  "An argument type provided by Endstone.");
+
+    py::classh<CommandNode>(m, "CommandNode", "Represents a node in a command tree.")
+        .def_property_readonly("name", &CommandNode::getName, "The name of this node.")
+        .def_property_readonly("children", &CommandNode::getChildren, "The children of this node.")
+        .def_property_readonly("is_executable", &CommandNode::isExecutable,
+                               "Whether a command may end at this node.")
+        .def_property_readonly("permissions", &CommandNode::getPermissions,
+                               "The permissions that allow this branch to be used.");
+
+    py::classh<LiteralCommandNode, CommandNode>(m, "LiteralCommandNode",
+                                                "A node matched by typing a fixed word.")
+        .def_property_readonly("description", &LiteralCommandNode::getDescription,
+                               "A brief description of this command.")
+        .def_property_readonly("aliases", &LiteralCommandNode::getAliases,
+                               "The alternative names this command is registered under.");
+
+    py::classh<ArgumentCommandNode, CommandNode>(m, "ArgumentCommandNode",
+                                                 "A node matched by parsing a value.");
+
+    auto literal_builder = py::class_<LiteralArgumentBuilder>(m, "LiteralArgumentBuilder",
+                                                            "Builds a node matched by typing a fixed word.");
+    auto required_builder = py::class_<RequiredArgumentBuilder>(m, "RequiredArgumentBuilder",
+                                                              "Builds a node matched by parsing a value.");
+
+    literal_builder
+        .def(
+            "description",
+            [](LiteralArgumentBuilder &self, std::string description) {
+                return self.description(std::move(description));
+            },
+            py::arg("description"), "Sets a brief description of this command.")
+        .def(
+            "aliases",
+            [](LiteralArgumentBuilder &self, const std::vector<std::string> &aliases) {
+                auto builder = self;
+                for (const auto &alias : aliases) {
+                    builder = builder.aliases(alias);
+                }
+                return builder;
+            },
+            py::arg("aliases"), "Adds alternative names this command may be typed as.")
+        .def("register_to", &LiteralArgumentBuilder::registerTo, py::arg("command_map"), py::arg("owner"), R"doc(
+    Registers this command tree.
+
+    Args:
+        command_map: The `CommandMap` to register to.
+        owner: The plugin the command belongs to.
+
+    Returns:
+        `True` on success, `False` if a command with the same name is already registered.
+)doc");
+
+    bindBuilder(literal_builder);
+    bindBuilder(required_builder);
+
+    py::class_<Commands>(m, "Commands", "Entry points for building a command tree.")
+        .def_static("literal", &Commands::literal, py::arg("name"),
+                    "Begins a branch matched by typing a fixed word.")
+        .def_static("argument", &Commands::argument, py::arg("name"), py::arg("type"),
+                    "Begins a branch matched by parsing a value.");
+
+    py::class_<CommandContext>(m, "CommandContext", "The arguments and sender a command handler is invoked with.")
+        .def_property_readonly("sender", &CommandContext::getSender, "The source of this command.")
+        .def_property_readonly("command", &CommandContext::getCommand, py::return_value_policy::reference,
+                               "The command being executed.")
+        .def_property_readonly("argument_names", &CommandContext::getArgumentNames,
+                               "The names of the arguments bound on the branch that ran.")
+        .def(
+            "__contains__",
+            [](const CommandContext &self, const std::string &name) { return self.has(name); }, py::arg("name"))
+        .def(
+            "__getitem__",
+            [](const CommandContext &self, const std::string &name) {
+                const auto *value = self.find(name);
+                if (!value) {
+                    throw py::key_error(name);
+                }
+                return toPython(*value);
+            },
+            py::arg("name"))
+        .def(
+            "get",
+            [](const CommandContext &self, const std::string &name, py::object default_value) {
+                const auto *value = self.find(name);
+                return value ? toPython(*value) : std::move(default_value);
+            },
+            py::arg("name"), py::arg("default") = py::none(),
+            "Returns the value of the named argument, or the default if it was omitted.");
+
+    auto arguments = m.def_submodule("arguments", "Factories for the argument types Endstone provides.");
+    arguments.def("boolean", &Arguments::boolean, "A boolean, suggested as true or false.");
+    arguments.def("integer", &Arguments::integer, py::arg("minimum") = std::numeric_limits<int>::min(),
+                  py::arg("maximum") = std::numeric_limits<int>::max(), "An integer, optionally bounded.");
+    arguments.def("floating", &Arguments::floating, py::arg("minimum") = -std::numeric_limits<float>::infinity(),
+                  py::arg("maximum") = std::numeric_limits<float>::infinity(),
+                  "A floating-point number, optionally bounded.");
+    arguments.def("string", &Arguments::string, "A single word, or a quoted string if it contains spaces.");
+    arguments.def("message", &Arguments::message, "Everything up to the end of the line.");
+    arguments.def("raw_text", &Arguments::rawText, "Everything up to the end of the line, taken verbatim.");
+    arguments.def("player", &Arguments::player, "A target selector resolving to exactly one player.");
+    arguments.def("players", &Arguments::players, "A target selector resolving to any number of players.");
+    arguments.def("entity", &Arguments::entity, "A target selector resolving to exactly one actor.");
+    arguments.def("entities", &Arguments::entities, "A target selector resolving to any number of actors.");
+    arguments.def("block_position", &Arguments::blockPosition, "A block position.");
+    arguments.def("position", &Arguments::position, "A precise position.");
+    arguments.def("block_type", &Arguments::blockType, "A block type.");
+    arguments.def("block_states", &Arguments::blockStates, "A list of block states.");
+    arguments.def("entity_type", &Arguments::entityType, "An actor type.");
+    arguments.def("json", &Arguments::json, "A JSON object.");
+    arguments.def("integer_range", &Arguments::integerRange, "An integer range, such as 3, 3.., ..7 or 3..7.");
+    arguments.def("enumeration", &Arguments::enumeration, py::arg("name"), py::arg("values"),
+                  "One of a fixed set of values, validated by the server.");
+    arguments.def("soft_enum", &Arguments::softEnum, py::arg("name"), R"doc(
+    A string completed from a named set of suggestions that can change at runtime.
+
+    Update the set with `CommandMap.set_suggestions()`. The values are only a hint to the client:
+    the server accepts any string, so validate the value in your handler.
+)doc");
+}
+
+}  // namespace endstone::python

--- a/src/endstone/python/endstone_python.cpp
+++ b/src/endstone/python/endstone_python.cpp
@@ -32,6 +32,7 @@ void init_block(py::module_ &, py::classh<Block> &block);
 void init_boss(py::module_ &);
 void init_color_format(py::module_ &);
 void init_command(py::module &, py_class<CommandSender> &command_sender);
+void init_command_tree(py::module_ &);
 void init_damage(py::module_ &);
 void init_enchantments(py::module_ &);
 void init_event(py::module_ &, py::class_<Event, PyEvent> &event);
@@ -222,6 +223,9 @@ PYBIND11_MODULE(_python, m)  // NOLINT(*-use-anonymous-namespace)
     init_boss(m_boss);
     init_command(m_command, command_sender);
     init_plugin(m_plugin);
+    // init_command_tree after init_plugin: registerTo takes a Plugin, and pybind11 bakes the
+    // signature at definition time, so Plugin has to be a registered type by then.
+    init_command_tree(m_command);
     init_scheduler(m_scheduler);
     init_permissions(m_permissions, permissible, permission);
     init_registry(m);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(endstone_test
         bedrock/test_binary_stream.cpp
         bedrock/test_block_pos.cpp
         bedrock/test_check.cpp
+        bedrock/test_command_selector.cpp
         bedrock/test_function_ref.cpp
         bedrock/test_hashed_string.cpp
         bedrock/test_sem_version.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(endstone_test
         test_nbt.cpp
         test_base64.cpp
         test_command_lexer.cpp
+        test_command_tree.cpp
         test_command_usage_parser.cpp
         test_cpp_plugin_loader.cpp
         test_effect.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(endstone_test
         bedrock/test_uuid.cpp
         test_identifier.cpp
         test_nbt.cpp
+        test_argument_types.cpp
         test_base64.cpp
         test_command_lexer.cpp
         test_command_tree.cpp

--- a/tests/bedrock/test_command_selector.cpp
+++ b/tests/bedrock/test_command_selector.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "bedrock/server/commands/command_selector.h"
+
+TEST(CommandSelectorTest, SelectorsAreTheSameSizeAsTheirBase)
+{
+    EXPECT_EQ(sizeof(CommandSelector<Actor>), sizeof(CommandSelectorBase));
+    EXPECT_EQ(sizeof(CommandSelector<Player>), sizeof(CommandSelectorBase));
+}
+
+TEST(CommandSelectorTest, SelectionTypeMatchesTheGameValues)
+{
+    EXPECT_EQ(static_cast<int>(CommandSelectionType::Self), 0);
+    EXPECT_EQ(static_cast<int>(CommandSelectionType::Entities), 1);
+    EXPECT_EQ(static_cast<int>(CommandSelectionType::Players), 2);
+    EXPECT_EQ(static_cast<int>(CommandSelectionType::DefaultPlayers), 3);
+    EXPECT_EQ(static_cast<int>(CommandSelectionType::OwnedAgent), 4);
+    EXPECT_EQ(static_cast<int>(CommandSelectionType::Agents), 5);
+    EXPECT_EQ(static_cast<int>(CommandSelectionType::Initiator), 6);
+}
+
+TEST(CommandSelectorTest, SelectionOrderMatchesTheGameValues)
+{
+    EXPECT_EQ(static_cast<int>(CommandSelectionOrder::Sorted), 0);
+    EXPECT_EQ(static_cast<int>(CommandSelectionOrder::InverseSorted), 1);
+    EXPECT_EQ(static_cast<int>(CommandSelectionOrder::Random), 2);
+}

--- a/tests/bedrock/test_command_selector.cpp
+++ b/tests/bedrock/test_command_selector.cpp
@@ -39,3 +39,16 @@ TEST(CommandSelectorTest, SelectionOrderMatchesTheGameValues)
     EXPECT_EQ(static_cast<int>(CommandSelectionOrder::InverseSorted), 1);
     EXPECT_EQ(static_cast<int>(CommandSelectionOrder::Random), 2);
 }
+
+TEST(CommandSelectorTest, DefaultsMatchTheGameConstructor)
+{
+    const CommandSelector<Actor> selector;
+
+    EXPECT_EQ(selector.getType(), CommandSelectionType::Self);
+    EXPECT_EQ(selector.getOrder(), CommandSelectionOrder::Sorted);
+    EXPECT_FALSE(selector.isExplicitIdSelector());
+
+    // A zero-initialised selector would count zero targets and search a zero radius, so it would
+    // silently match nothing. The game constructor starts unbounded.
+    EXPECT_EQ(selector.getResultCount(), CommandSelectorBase::Unlimited);
+}

--- a/tests/test_argument_types.cpp
+++ b/tests/test_argument_types.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "endstone/command/arguments.h"
+#include "endstone/core/command/tree/argument_types.h"
+
+using endstone::ArgumentKind;
+using endstone::Arguments;
+using endstone::ArgumentType;
+using endstone::ArgumentValue;
+using endstone::CommandSender;
+using endstone::NotNull;
+using endstone::Nullable;
+using endstone::core::effectiveArgumentKind;
+using endstone::core::isSelectorArgument;
+
+namespace {
+
+class WrappingArgument : public ArgumentType {
+public:
+    explicit WrappingArgument(NotNull<ArgumentType> native) : native_(std::move(native)) {}
+
+    [[nodiscard]] Nullable<ArgumentType> getNativeType() const override { return native_.get(); }
+
+private:
+    NotNull<ArgumentType> native_;
+};
+
+}  // namespace
+
+TEST(ArgumentTypesTest, BuiltinKindsAreReportedDirectly)
+{
+    EXPECT_EQ(effectiveArgumentKind(*Arguments::integer()), ArgumentKind::Integer);
+    EXPECT_EQ(effectiveArgumentKind(*Arguments::string()), ArgumentKind::String);
+    EXPECT_EQ(effectiveArgumentKind(*Arguments::players()), ArgumentKind::Players);
+}
+
+TEST(ArgumentTypesTest, OnlySelectorKindsAreSelectors)
+{
+    EXPECT_TRUE(isSelectorArgument(ArgumentKind::Player));
+    EXPECT_TRUE(isSelectorArgument(ArgumentKind::Players));
+    EXPECT_TRUE(isSelectorArgument(ArgumentKind::Entity));
+    EXPECT_TRUE(isSelectorArgument(ArgumentKind::Entities));
+
+    EXPECT_FALSE(isSelectorArgument(ArgumentKind::String));
+    EXPECT_FALSE(isSelectorArgument(ArgumentKind::Integer));
+    EXPECT_FALSE(isSelectorArgument(ArgumentKind::EntityType));
+    EXPECT_FALSE(isSelectorArgument(ArgumentKind::Custom));
+}
+
+TEST(ArgumentTypesTest, CustomTypeReportsTheKindItIsPresentedAs)
+{
+    // A custom type borrows a built-in type's grammar, so it has to be stored and parsed as that
+    // built-in - a custom type over player() still needs selector storage.
+    const auto over_player = std::make_shared<WrappingArgument>(Arguments::player());
+    EXPECT_EQ(effectiveArgumentKind(*over_player), ArgumentKind::Player);
+    EXPECT_TRUE(isSelectorArgument(effectiveArgumentKind(*over_player)));
+
+    const auto over_string = std::make_shared<WrappingArgument>(Arguments::string());
+    EXPECT_EQ(effectiveArgumentKind(*over_string), ArgumentKind::String);
+    EXPECT_FALSE(isSelectorArgument(effectiveArgumentKind(*over_string)));
+}
+
+TEST(ArgumentTypesTest, NestedCustomTypesFollowTheWholeChain)
+{
+    const auto inner = std::make_shared<WrappingArgument>(Arguments::entities());
+    const auto outer = std::make_shared<WrappingArgument>(inner);
+    EXPECT_EQ(effectiveArgumentKind(*outer), ArgumentKind::Entities);
+}
+
+TEST(ArgumentTypesTest, CustomTypeWithoutANativeTypeStaysCustom)
+{
+    class Bare : public ArgumentType {};
+    const Bare bare;
+    EXPECT_EQ(effectiveArgumentKind(bare), ArgumentKind::Custom);
+}

--- a/tests/test_command_tree.cpp
+++ b/tests/test_command_tree.cpp
@@ -1,0 +1,200 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "endstone/command/arguments.h"
+#include "endstone/command/command_builder.h"
+#include "endstone/core/command/tree/command_tree.h"
+
+using endstone::Arguments;
+using endstone::CommandContext;
+using endstone::Commands;
+using endstone::core::CommandTreeOverload;
+using endstone::core::flattenCommandTree;
+using endstone::core::MAX_OVERLOADS_PER_COMMAND;
+
+namespace {
+
+void noop(const CommandContext &) {}
+
+std::vector<std::string> shapeOf(const CommandTreeOverload &overload)
+{
+    std::vector<std::string> shape;
+    for (const auto &slot : overload.slots) {
+        shape.push_back(slot.node->getName());
+    }
+    return shape;
+}
+
+std::vector<std::string> pathOf(const CommandTreeOverload &overload)
+{
+    std::vector<std::string> path;
+    for (const auto &node : overload.path) {
+        path.push_back(node->getName());
+    }
+    return path;
+}
+
+}  // namespace
+
+TEST(CommandTreeTest, RootOnlyYieldsOneEmptyOverload)
+{
+    const auto root = Commands::literal("ping").executes(noop).build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    ASSERT_EQ(result->size(), 1);
+    EXPECT_THAT(shapeOf(result->front()), testing::IsEmpty());
+    EXPECT_EQ(result->front().leaf->getName(), "ping");
+}
+
+TEST(CommandTreeTest, EachExecutableNodeBecomesAnOverload)
+{
+    const auto root =
+        Commands::literal("warp")
+            .then(Commands::literal("add").then(Commands::argument("name", Arguments::string()).executes(noop)))
+            .then(Commands::literal("list").executes(noop))
+            .build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    ASSERT_EQ(result->size(), 2);
+    EXPECT_THAT(shapeOf(result->at(0)), testing::ElementsAre("add", "name"));
+    EXPECT_THAT(shapeOf(result->at(1)), testing::ElementsAre("list"));
+}
+
+TEST(CommandTreeTest, ExecutableParentAndChildBothYieldOverloads)
+{
+    const auto root = Commands::literal("home")
+                          .executes(noop)
+                          .then(Commands::argument("name", Arguments::string()).executes(noop))
+                          .build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    ASSERT_EQ(result->size(), 2);
+    EXPECT_THAT(shapeOf(result->at(0)), testing::IsEmpty());
+    EXPECT_THAT(shapeOf(result->at(1)), testing::ElementsAre("name"));
+}
+
+TEST(CommandTreeTest, PathRunsFromRootToLeaf)
+{
+    const auto root =
+        Commands::literal("warp")
+            .then(Commands::literal("add").then(Commands::argument("name", Arguments::string()).executes(noop)))
+            .build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    ASSERT_EQ(result->size(), 1);
+    EXPECT_THAT(pathOf(result->front()), testing::ElementsAre("warp", "add", "name"));
+}
+
+TEST(CommandTreeTest, RejectsTreeWithNoExecutableNode)
+{
+    const auto root = Commands::literal("warp").then(Commands::literal("add")).build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error(), testing::HasSubstr("no branch that does anything"));
+}
+
+TEST(CommandTreeTest, RejectsArgumentAfterGreedyMessage)
+{
+    const auto root = Commands::literal("say")
+                          .then(Commands::argument("text", Arguments::message())
+                                    .then(Commands::argument("extra", Arguments::string()).executes(noop)))
+                          .build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error(), testing::HasSubstr("must be the last one"));
+}
+
+TEST(CommandTreeTest, RejectsArgumentAfterGreedyRawText)
+{
+    const auto root = Commands::literal("say")
+                          .then(Commands::argument("text", Arguments::rawText())
+                                    .then(Commands::argument("extra", Arguments::string()).executes(noop)))
+                          .build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error(), testing::HasSubstr("must be the last one"));
+}
+
+TEST(CommandTreeTest, AllowsGreedyMessageAsTheLastArgument)
+{
+    const auto root =
+        Commands::literal("say").then(Commands::argument("text", Arguments::message()).executes(noop)).build();
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_THAT(shapeOf(result->front()), testing::ElementsAre("text"));
+}
+
+TEST(CommandTreeTest, RejectsCycle)
+{
+    const auto root = Commands::literal("loop").build();
+    const auto child = Commands::literal("again").executes(noop).build();
+    child->addChild(root);
+    root->addChild(child);
+
+    const auto result = flattenCommandTree(root);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error(), testing::HasSubstr("reachable from itself"));
+}
+
+TEST(CommandTreeTest, RejectsMoreOverloadsThanTheBudget)
+{
+    auto root = Commands::literal("wide");
+    for (std::size_t i = 0; i <= MAX_OVERLOADS_PER_COMMAND; ++i) {
+        root = root.then(Commands::literal("branch" + std::to_string(i)).executes(noop));
+    }
+
+    const auto result = flattenCommandTree(root.build());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error(), testing::HasSubstr("Too many branches"));
+}
+
+TEST(CommandTreeTest, MergesChildrenWithTheSameName)
+{
+    const auto root =
+        Commands::literal("warp")
+            .then(Commands::literal("add").then(Commands::argument("name", Arguments::string()).executes(noop)))
+            .then(Commands::literal("add").then(Commands::argument("other", Arguments::string()).executes(noop)))
+            .build();
+
+    ASSERT_EQ(root->getChildren().size(), 1);
+    const auto result = flattenCommandTree(root);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    ASSERT_EQ(result->size(), 2);
+    EXPECT_THAT(shapeOf(result->at(0)), testing::ElementsAre("add", "name"));
+    EXPECT_THAT(shapeOf(result->at(1)), testing::ElementsAre("add", "other"));
+}
+
+TEST(CommandTreeTest, MergeCombinesRequirementsRatherThanKeepingTheFirst)
+{
+    const auto first = Commands::literal("run").permission("a").executes(noop).build();
+    const auto second = Commands::literal("run").permission("b").executes(noop).build();
+    const auto root = Commands::literal("warp").then(first).then(second).build();
+
+    ASSERT_EQ(root->getChildren().size(), 1);
+    EXPECT_THAT(root->getChildren().front()->getPermissions(), testing::ElementsAre("a", "b"));
+}

--- a/tests/test_command_tree.py
+++ b/tests/test_command_tree.py
@@ -1,0 +1,108 @@
+from typing import Annotated
+
+import pytest
+
+from endstone import Player
+from endstone.command import CommandContext, command
+from endstone.command import arguments as arg
+from endstone.command._tree import build_command_trees
+
+
+class Warps:
+    """Stands in for a plugin: the decorators only need an object to hang methods off."""
+
+    @command(description="Manage warps.", aliases=["w"], permission="my_plugin.command.warp")
+    def warp(self, ctx: CommandContext) -> None: ...
+
+    @warp.subcommand()
+    def add(self, ctx: CommandContext, name: str) -> None: ...
+
+    @warp.subcommand(permission="my_plugin.command.warp.others")
+    def tp(
+        self,
+        ctx: CommandContext,
+        name: Annotated[str, arg.soft_enum("my_plugin:warps")],
+        amount: Annotated[int, arg.integer(1, 64)] = 1,
+        who: list[Player] | None = None,
+    ) -> None: ...
+
+
+def shape(node) -> dict:
+    return {
+        "name": node.name,
+        "executable": node.is_executable,
+        "permissions": list(node.permissions),
+        "children": [shape(child) for child in node.children],
+    }
+
+
+@pytest.fixture
+def root():
+    trees = build_command_trees(Warps())
+    assert len(trees) == 1
+    return trees[0].build()
+
+
+class TestCommandDecorator:
+    def test_root_carries_the_command_metadata(self, root) -> None:
+        assert root.name == "warp"
+        assert root.description == "Manage warps."
+        assert list(root.aliases) == ["w"]
+        assert list(root.permissions) == ["my_plugin.command.warp"]
+
+    def test_a_handler_with_no_arguments_makes_the_literal_executable(self, root) -> None:
+        assert root.is_executable
+
+    def test_subcommands_become_children_named_after_the_method(self, root) -> None:
+        assert [child.name for child in root.children] == ["add", "tp"]
+
+    def test_a_mandatory_argument_moves_the_handler_off_the_literal(self, root) -> None:
+        add = next(child for child in root.children if child.name == "add")
+        assert not add.is_executable
+
+        name = add.children[0]
+        assert name.name == "name"
+        assert name.is_executable
+
+    def test_every_optional_argument_can_end_the_command(self, root) -> None:
+        tp = next(child for child in root.children if child.name == "tp")
+        assert not tp.is_executable
+
+        # /warp tp <name> [amount] [who] - each optional step is its own executable node.
+        name = tp.children[0]
+        amount = name.children[0]
+        who = amount.children[0]
+        assert [name.name, amount.name, who.name] == ["name", "amount", "who"]
+        assert all(node.is_executable for node in (name, amount, who))
+        assert who.children == []
+
+    def test_a_subcommand_keeps_its_own_permission(self, root) -> None:
+        tp = next(child for child in root.children if child.name == "tp")
+        assert list(tp.permissions) == ["my_plugin.command.warp.others"]
+
+
+class TestArgumentInference:
+    def test_an_unannotated_argument_is_rejected(self) -> None:
+        class Bad:
+            @command()
+            def broken(self, ctx: CommandContext, name) -> None: ...
+
+        with pytest.raises(TypeError, match="needs an annotation"):
+            build_command_trees(Bad())
+
+    def test_an_unmappable_annotation_is_rejected(self) -> None:
+        class Bad:
+            @command()
+            def broken(self, ctx: CommandContext, when: complex) -> None: ...
+
+        with pytest.raises(TypeError, match="has no argument type"):
+            build_command_trees(Bad())
+
+    def test_a_bare_annotation_picks_the_matching_argument_type(self) -> None:
+        class Plain:
+            @command()
+            def echo(self, ctx: CommandContext, count: int, message: str) -> None: ...
+
+        root = build_command_trees(Plain())[0].build()
+        count = root.children[0]
+        assert [count.name, count.children[0].name] == ["count", "message"]


### PR DESCRIPTION
Adds the command tree API from [ROADMAP.md](ROADMAP.md) §3.1.

```cpp
Commands::literal("warp")
    .description("Manage warps.")
    .permission("my_plugin.command.warp")
    .then(Commands::literal("tp")
        .then(Commands::argument("name", Arguments::softEnum("my_plugin:warps"))
            .then(Commands::argument("who", Arguments::players())
                .permission("my_plugin.command.warp.others")
                .executes([this](const CommandContext &ctx) {
                    for (const auto &p : ctx.get<std::vector<NotNull<Player>>>("who")) {
                        tp(p, ctx.get<std::string>("name"));
                    }
                }))))
    .registerTo(getServer().getCommandMap(), *this);
```

Python declares the same tree with decorators, since that nesting is Java's shape rather than
Python's. Arguments are the handler's own parameters: a bare annotation picks the argument type,
`Annotated` carries one where the type alone will not do, and a default makes the argument
optional.

```python
class MyPlugin(Plugin):
    @command(description="Manage warps.", permission="my_plugin.command.warp")
    def warp(self, ctx: CommandContext) -> None:
        """Bare /warp."""

    @warp.subcommand(permission="my_plugin.command.warp.others")
    def tp(
        self,
        ctx: CommandContext,
        name: Annotated[str, arg.soft_enum("my_plugin:warps")],
        amount: Annotated[int, arg.integer(1, 64)] = 1,
        who: list[Player] | None = None,
    ) -> None:
        ...

    def on_enable(self) -> None:
        self.register_commands()
```

That gives `/warp`, `/warp tp <name>`, then `[amount]` and `[who]`, each able to end the command.
Metadata goes in the decorator rather than beside the arguments, so a permission cannot collide
with a parameter named `permission`. The decorator is pure Python, the way `event_handler` is, so
none of it has to be maintained in the bindings. The builders are bound too, for a tree assembled
at runtime from config, where a decorator cannot reach.

> [!IMPORTANT]
> **Draft: this targets 0.13, and `develop` is currently 0.12.** Merging it as-is would put it in
> the 0.12 release. It also has no CHANGELOG entry yet, deliberately — `[Unreleased]` belongs to
> 0.12, and two unreleased sections would break Keep a Changelog. The entry goes in once `develop`
> rolls over.

## Why this shape

Usage strings stay. They are still the right answer for a flat command, and nothing about them
changes: usage-string parameters keep the existing text-capture parse rule, so `args` is
byte-for-byte what it was. This is additive.

Three things the usage-string API cannot do, which this fixes:

- **Overloads are indistinguishable at dispatch.** The adapter hands the command a bare `args`
  vector with no record of which overload matched, which is why `/ban` registers `<name: str>` and
  `<name: player>` and then has to guess.
- **Everything is a string.** The grammar is validated, but the parse rule only kept the raw text,
  so plugins re-parsed ints, re-resolved players, and could not resolve a selector at all.
- **Branching is manual** — an enum parameter plus an `if`/`match` ladder.

## How it maps onto the command registry

The registry has no node graph to register against: a command is a name and a list of overloads,
each a flat parameter list. So every root-to-`executes()` path becomes one overload, with literals
registered as single-value enums — which is what the client already renders as the word to type,
so branches keep native completion.

Each overload binds its own allocator, so the adapter that runs always knows which branch parsed.
Emitting one all-mandatory overload per executable node also sidesteps the registry's
trailing-optional-only restriction, which cannot express an optional in the middle of a list.

Parameters are addressed by slot index rather than arrival order, through `CommandParameterData`'s
custom storage accessors, so a parameter can be parsed straight into a typed value instead of text.

## Two deliberate departures from Brigadier

- Arguments are read with `ctx.get<T>("name")` rather than a stringly-typed
  `getArgument(name, Class)`, so the type is fixed at the call site, and a wrong name reports the
  names actually bound on that branch.
- A branch can be gated by `permission()`, which tells the sender they lack permission, as well as
  by the silent `requires()` Brigadier offers — where a failed requirement is indistinguishable
  from an unknown command. Both hide the branch from the client, via `updateCommands()`.

Argument values are keyed on the mangled type name rather than held in `std::any`, and node and
argument kinds are virtual accessors rather than `dynamic_cast`, because typeinfo identity does not
survive the plugin boundary on Linux.

## Selectors

`player()`, `players()`, `entity()` and `entities()` resolve to real actors. This needed
`CommandSelector` reconstructing, and two new symbols per platform. Both resolve on Windows and
Linux against the supported server version.

## Two pre-existing bugs fixed on the way

- `CommandRegistry::registerOverload<T>` applied registration to a temporary rather than the
  registered overload, so anything that relied on the registry resolving a parameter's symbol would
  have got an unresolved one. It worked only because `EndstoneCommandMap` pre-resolves every symbol
  by hand.
- `findEnum` returned a mis-tagged symbol; latent because the one caller masks the tag off.

## Not in this PR

`blockPosition()`, `position()`, `blockStates()` and `integerRange()` are rejected at registration
with an explicit message rather than silently degrading. Custom argument types defined in Python
are not supported yet. Literal coalescing and trailing-optional collapse, usage strings lowered
onto the shared backend, and the docs are all still to come.

## Testing

353 C++ tests pass, 21 of them new: the flattener (literal merging, greedy-not-last, cycles, the
overload budget, merge semantics), the selector layout and its default construction, and argument
kind resolution through the custom-type chain. 9 new Python tests cover the decorator — the tree
shape it produces, optional arguments, per-branch permissions, and the errors for an unannotated or
unmappable parameter.

**Nothing here has run against a live server yet** — the `/test` pass still needs doing, and that is
the real check for registration, dispatch and per-player visibility.
