### PR TITLE
feat(player): add a type-safe Ability API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Actors and players
 
+- Ability API: `Player.get_ability()` and `Player.set_ability()`, keyed by an `Ability` constant that carries its own value type. `Ability.NO_CLIP` takes a bool, `Ability.FLY_SPEED` takes a float, and in C++ swapping the two is a compile error. All twenty Bedrock abilities are covered, including the eight member permissions the client shows in its pause menu — `BUILD`, `MINE`, `DOORS_AND_SWITCHES`, `OPEN_CONTAINERS`, `ATTACK_PLAYERS`, `ATTACK_MOBS`, `OPERATOR_COMMANDS` and `TELEPORT` — every one of which the server enforces. Abilities can also be looked up with `Ability.get()` and enumerated via `server.get_registry(Ability)`. Reading an ability gives the value in effect, which spectator mode and the editor can override; writing sets the player's own value. Bedrock does not save abilities for a player whose permissions the server manages, so set them again when the player rejoins.
 - Attribute API: `Mob.get_attribute()`, `Mob.has_attribute()` and `Mob.attributes`. Each `AttributeInstance` reports its current, base, minimum and maximum value and takes `AttributeModifier`s at runtime.
 - Effect API: `Mob.add_effect()`, `Mob.remove_effect()`, `Mob.has_effect()`, `Mob.get_effect()` and `Mob.active_effects`, with the new `Effect` type carrying effect type, duration, amplifier and the ambient/particles/icon flags.
 - `Mob.is_swimming` and `Player.is_crawling`.

--- a/endstone/__init__.py
+++ b/endstone/__init__.py
@@ -10,6 +10,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
         "_python": [
+            "Ability",
             "ColorFormat",
             "GameMode",
             "GameRule",

--- a/endstone/__init__.pyi
+++ b/endstone/__init__.pyi
@@ -49,6 +49,7 @@ from . import (
 from ._version import __version__
 
 __all__ = [
+    "Ability",
     "ColorFormat",
     "GameMode",
     "GameRule",
@@ -856,6 +857,122 @@ class Player(Mob):
             packet_id: The packet ID to be sent.
             payload: The payload of the packet to be transmitted.
         """
+
+    @typing.overload
+    def get_ability(self, ability: Identifier[Ability[_T]]) -> _T: ...
+    @typing.overload
+    def get_ability(self, ability: str) -> bool | float:
+        """
+        Gets the value of an ability.
+
+        The value returned is the one in effect, which is not always the one that was set: while the player is
+        spectating, or has the loading screen up, or is in the editor, that state supplies its own value for some
+        abilities and it takes precedence over the player's own.
+
+        Args:
+            ability: The Minecraft ability to get.
+
+        Returns:
+            The current ability value.
+
+        Raises:
+            IndexError: If the ability does not exist.
+        """
+
+    @typing.overload
+    def set_ability(self, ability: Identifier[Ability[_T]], value: _T) -> None: ...
+    @typing.overload
+    def set_ability(self, ability: str, value: bool | float) -> None:
+        """
+        Sets the value of an ability.
+
+        Abilities are not persisted for a player whose permissions are managed by the server, so a plugin that wants a
+        value to outlast the session must set it again when the player rejoins. `Ability.MUTED`, `Ability.NO_CLIP`,
+        `Ability.PRIVILEGED_BUILDER` and `Ability.WORLD_BUILDER` are never saved at all.
+
+        Args:
+            ability: The Minecraft ability to set.
+            value: The new value, which must match the type of the ability.
+
+        Raises:
+            ValueError: If the ability does not exist or the value has the wrong type.
+        """
+
+class Ability(typing.Generic[_T]):
+    """
+    All player abilities.
+
+    `ATTACK_MOBS`, `ATTACK_PLAYERS`, `BUILD`, `DOORS_AND_SWITCHES`, `MINE`, `OPEN_CONTAINERS`, `OPERATOR_COMMANDS`
+    and `TELEPORT` are the eight member permissions the client shows in its pause menu, and the server enforces
+    every one of them.
+    """
+    def __hash__(self) -> int: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __ne__(self, other: object) -> bool: ...
+    @property
+    def id(self) -> Identifier[Ability[_T]]:
+        """
+        The identifier of this ability.
+        """
+
+    @property
+    def translation_key(self) -> str:
+        """
+        The translation key of this ability.
+        """
+
+    @typing.overload
+    @staticmethod
+    def get(name: Identifier[Ability[_T]]) -> Ability[_T] | None: ...
+    @typing.overload
+    @staticmethod
+    def get(name: str) -> Ability[typing.Any] | None:
+        """
+        Attempts to get the `Ability` with the given name.
+
+        Args:
+            name: The identifier of the ability (e.g. `minecraft:noclip`).
+
+        Returns:
+            The `Ability`, or `None` if no ability with that name exists.
+        """
+
+    ATTACK_MOBS: Identifier[Ability[bool]] = "minecraft:attackmobs"
+
+    ATTACK_PLAYERS: Identifier[Ability[bool]] = "minecraft:attackplayers"
+
+    BUILD: Identifier[Ability[bool]] = "minecraft:build"
+
+    DOORS_AND_SWITCHES: Identifier[Ability[bool]] = "minecraft:doorsandswitches"
+
+    FLYING: Identifier[Ability[bool]] = "minecraft:flying"
+
+    FLY_SPEED: Identifier[Ability[float]] = "minecraft:flyspeed"
+    INSTABUILD: Identifier[Ability[bool]] = "minecraft:instabuild"
+
+    INVULNERABLE: Identifier[Ability[bool]] = "minecraft:invulnerable"
+
+    LIGHTNING: Identifier[Ability[bool]] = "minecraft:lightning"
+
+    MAY_FLY: Identifier[Ability[bool]] = "minecraft:mayfly"
+
+    MINE: Identifier[Ability[bool]] = "minecraft:mine"
+
+    MUTED: Identifier[Ability[bool]] = "minecraft:mute"
+
+    NO_CLIP: Identifier[Ability[bool]] = "minecraft:noclip"
+
+    OPEN_CONTAINERS: Identifier[Ability[bool]] = "minecraft:opencontainers"
+
+    OPERATOR_COMMANDS: Identifier[Ability[bool]] = "minecraft:op"
+
+    PRIVILEGED_BUILDER: Identifier[Ability[bool]] = "minecraft:privilegedbuilder"
+
+    TELEPORT: Identifier[Ability[bool]] = "minecraft:teleport"
+
+    VERTICAL_FLY_SPEED: Identifier[Ability[float]] = "minecraft:verticalflyspeed"
+    WALK_SPEED: Identifier[Ability[float]] = "minecraft:walkspeed"
+    WORLD_BUILDER: Identifier[Ability[bool]] = "minecraft:worldbuilder"
 
 class ColorFormat:
     """

--- a/include/endstone/ability.h
+++ b/include/endstone/ability.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+#include <variant>
+
+#include "endstone/registry.h"
+
+namespace endstone {
+
+using AbilityValue = std::variant<bool, float>;
+
+class Ability;
+
+/**
+ * Represents the identifier of a player ability, carrying the type of the ability's value.
+ */
+template <typename T>
+class AbilityId : public Identifier<Ability> {
+public:
+    using Identifier::Identifier;
+
+    static constexpr AbilityId minecraft(const std::string_view key) noexcept { return {Minecraft, key}; }
+};
+
+/**
+ * All player abilities.
+ *
+ * AttackMobs, AttackPlayers, Build, DoorsAndSwitches, Mine, OpenContainers, OperatorCommands and Teleport are the
+ * eight member permissions the client shows in its pause menu, and the server enforces every one of them.
+ */
+class Ability : public Registry<Ability>::Type {
+public:
+    /** Whether the player can attack mobs. */
+    static constexpr auto AttackMobs = AbilityId<bool>::minecraft("attackmobs");
+    /** Whether the player can attack other players. */
+    static constexpr auto AttackPlayers = AbilityId<bool>::minecraft("attackplayers");
+    /** Whether the player can place blocks. */
+    static constexpr auto Build = AbilityId<bool>::minecraft("build");
+    /** Whether the player can use doors, trapdoors, buttons, levers and other redstone components. */
+    static constexpr auto DoorsAndSwitches = AbilityId<bool>::minecraft("doorsandswitches");
+    /** Whether the player is currently flying. */
+    static constexpr auto Flying = AbilityId<bool>::minecraft("flying");
+    /** The speed at which the player flies, default is `0.05`. */
+    static constexpr auto FlySpeed = AbilityId<float>::minecraft("flyspeed");
+    /** Whether the player destroys blocks instantly. */
+    static constexpr auto Instabuild = AbilityId<bool>::minecraft("instabuild");
+    /** Whether the player is immune to all damage. */
+    static constexpr auto Invulnerable = AbilityId<bool>::minecraft("invulnerable");
+    /** Whether the player was struck by lightning. */
+    static constexpr auto Lightning = AbilityId<bool>::minecraft("lightning");
+    /** Whether the player is allowed to fly. */
+    static constexpr auto MayFly = AbilityId<bool>::minecraft("mayfly");
+    /** Whether the player can destroy blocks. */
+    static constexpr auto Mine = AbilityId<bool>::minecraft("mine");
+    /** Whether the player's chat messages are hidden from other players. */
+    static constexpr auto Muted = AbilityId<bool>::minecraft("mute");
+    /** Whether the player can move through blocks. */
+    static constexpr auto NoClip = AbilityId<bool>::minecraft("noclip");
+    /** Whether the player can open containers. */
+    static constexpr auto OpenContainers = AbilityId<bool>::minecraft("opencontainers");
+    /** Whether the player can use operator commands. */
+    static constexpr auto OperatorCommands = AbilityId<bool>::minecraft("op");
+    /** Whether the player is a privileged builder. */
+    static constexpr auto PrivilegedBuilder = AbilityId<bool>::minecraft("privilegedbuilder");
+    /** Whether the player can teleport. */
+    static constexpr auto Teleport = AbilityId<bool>::minecraft("teleport");
+    /** The speed at which the player flies up and down, default is `1`. */
+    static constexpr auto VerticalFlySpeed = AbilityId<float>::minecraft("verticalflyspeed");
+    /** The speed at which the player walks, default is `0.1`. */
+    static constexpr auto WalkSpeed = AbilityId<float>::minecraft("walkspeed");
+    /** Whether the player is a world builder. */
+    static constexpr auto WorldBuilder = AbilityId<bool>::minecraft("worldbuilder");
+};
+
+static_assert(std::is_same_v<decltype(Ability::NoClip), const AbilityId<bool>>);
+static_assert(std::is_same_v<decltype(Ability::FlySpeed), const AbilityId<float>>);
+static_assert(std::is_same_v<decltype(Ability::VerticalFlySpeed), const AbilityId<float>>);
+static_assert(std::is_same_v<decltype(Ability::WalkSpeed), const AbilityId<float>>);
+
+}  // namespace endstone

--- a/include/endstone/endstone.hpp
+++ b/include/endstone/endstone.hpp
@@ -24,6 +24,7 @@ static_assert(_ITERATOR_DEBUG_LEVEL == 0,
               "Error: Endstone plugins must be built in Release or RelWithDebInfo mode with MSVC!");
 #endif
 
+#include "ability.h"
 #include "actor/actor.h"
 #include "actor/actor_type.h"
 #include "actor/item.h"

--- a/include/endstone/player.h
+++ b/include/endstone/player.h
@@ -20,6 +20,7 @@
 #include <string_view>
 #include <variant>
 
+#include "endstone/ability.h"
 #include "endstone/actor/mob.h"
 #include "endstone/form/action_form.h"
 #include "endstone/form/message_form.h"
@@ -521,6 +522,58 @@ public:
      * @param map The map to send
      */
     virtual void sendMap(MapView &map) = 0;
+
+    /**
+     * Gets the value of an ability.
+     *
+     * @param ability The Minecraft ability to get
+     * @return The current ability value
+     */
+    [[nodiscard]] virtual AbilityValue _getAbility(Identifier<Ability> ability) const = 0;
+
+    /**
+     * Gets the value of an ability.
+     *
+     * The value returned is the one in effect, which is not always the one that was set: while the player is
+     * spectating, or has the loading screen up, or is in the editor, that state supplies its own value for some
+     * abilities and it takes precedence over the player's own.
+     *
+     * @tparam T The type of the ability's value.
+     * @param ability The Minecraft ability to get
+     * @return The current ability value
+     */
+    template <typename T>
+    [[nodiscard]] T getAbility(AbilityId<T> ability) const
+    {
+        return std::get<T>(_getAbility(ability));
+    }
+
+    /**
+     * Sets the value of an ability.
+     *
+     * @param ability The Minecraft ability to set
+     * @param value The new value
+     * @return True if the value was accepted
+     */
+    virtual bool _setAbility(Identifier<Ability> ability, AbilityValue value) = 0;
+
+    /**
+     * Sets the value of an ability.
+     *
+     * Abilities are not persisted for a player whose permissions are managed by the server, so a plugin that wants
+     * a value to outlast the session must set it again when the player rejoins. Ability::Muted, Ability::NoClip,
+     * Ability::PrivilegedBuilder and Ability::WorldBuilder are never saved at all.
+     *
+     * @tparam T The type of the ability's value.
+     * @param ability The Minecraft ability to set
+     * @param value The new value
+     * @return True if the value was accepted
+     */
+    template <typename T>
+    bool setAbility(AbilityId<T> ability, T value)
+    {
+        return _setAbility(ability, value);
+    }
 };
 
 }  // namespace endstone

--- a/src/endstone/core/CMakeLists.txt
+++ b/src/endstone/core/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(tomlplusplus REQUIRED)
 find_package(zstr CONFIG REQUIRED)
 
 add_library(endstone_core
+        ability.cpp
         crash_handler.cpp
         game_mode.cpp
         game_rule.cpp

--- a/src/endstone/core/ability.cpp
+++ b/src/endstone/core/ability.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "endstone/core/ability.h"
+
+#include <format>
+
+namespace endstone::core {
+
+namespace {
+constexpr std::array<AbilityEntry, AbilityCount> AbilityTable{{
+    {Ability::AttackMobs, AbilitiesIndex::AttackMobs},
+    {Ability::AttackPlayers, AbilitiesIndex::AttackPlayers},
+    {Ability::Build, AbilitiesIndex::Build},
+    {Ability::DoorsAndSwitches, AbilitiesIndex::DoorsAndSwitches},
+    {Ability::Flying, AbilitiesIndex::Flying},
+    {Ability::FlySpeed, AbilitiesIndex::FlySpeed},
+    {Ability::Instabuild, AbilitiesIndex::Instabuild},
+    {Ability::Invulnerable, AbilitiesIndex::Invulnerable},
+    {Ability::Lightning, AbilitiesIndex::Lightning},
+    {Ability::MayFly, AbilitiesIndex::MayFly},
+    {Ability::Mine, AbilitiesIndex::Mine},
+    {Ability::Muted, AbilitiesIndex::Muted},
+    {Ability::NoClip, AbilitiesIndex::NoClip},
+    {Ability::OpenContainers, AbilitiesIndex::OpenContainers},
+    {Ability::OperatorCommands, AbilitiesIndex::OperatorCommands},
+    {Ability::PrivilegedBuilder, AbilitiesIndex::PrivilegedBuilder},
+    {Ability::Teleport, AbilitiesIndex::Teleport},
+    {Ability::VerticalFlySpeed, AbilitiesIndex::VerticalFlySpeed},
+    {Ability::WalkSpeed, AbilitiesIndex::WalkSpeed},
+    {Ability::WorldBuilder, AbilitiesIndex::WorldBuilder},
+}};
+}  // namespace
+
+EndstoneAbility::EndstoneAbility(const AbilityEntry &entry) : id_(entry.id), index_(entry.index) {}
+
+Identifier<Ability> EndstoneAbility::getId() const
+{
+    return id_;
+}
+
+std::string EndstoneAbility::getTranslationKey() const
+{
+    return std::format("permissions.ability.{}", id_.getKey());
+}
+
+AbilitiesIndex EndstoneAbility::getIndex() const
+{
+    return index_;
+}
+
+const std::array<AbilityEntry, AbilityCount> &EndstoneAbility::all()
+{
+    return AbilityTable;
+}
+
+}  // namespace endstone::core

--- a/src/endstone/core/ability.h
+++ b/src/endstone/core/ability.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <string>
+
+#include "bedrock/world/actor/player/abilities.h"
+#include "endstone/ability.h"
+
+namespace endstone::core {
+
+inline constexpr std::size_t AbilityCount = static_cast<std::size_t>(AbilitiesIndex::AbilityCount);
+
+struct AbilityEntry {
+    Identifier<Ability> id;
+    AbilitiesIndex index;
+};
+
+class EndstoneAbility : public Ability {
+public:
+    explicit EndstoneAbility(const AbilityEntry &entry);
+    [[nodiscard]] Identifier<Ability> getId() const override;
+    [[nodiscard]] std::string getTranslationKey() const override;
+    [[nodiscard]] AbilitiesIndex getIndex() const;
+
+    static const std::array<AbilityEntry, AbilityCount> &all();
+
+private:
+    Identifier<Ability> id_;
+    AbilitiesIndex index_;
+};
+
+}  // namespace endstone::core

--- a/src/endstone/core/player.cpp
+++ b/src/endstone/core/player.cpp
@@ -40,6 +40,7 @@
 #include "bedrock/world/level/dimension/vanilla_dimensions.h"
 #include "bedrock/world/level/level.h"
 #include "endstone/color_format.h"
+#include "endstone/core/ability.h"
 #include "endstone/core/base64.h"
 #include "endstone/core/entity/components/flag_components.h"
 #include "endstone/core/form/form_codec.h"
@@ -698,6 +699,46 @@ void EndstonePlayer::sendMap(MapView &map)
     }
     pk.payload.map_pixels.resize(pk.payload.width * pk.payload.height);
     getHandle().sendNetworkPacket(*packet);
+}
+
+AbilityValue EndstonePlayer::_getAbility(const Identifier<Ability> ability) const
+{
+    const auto *entry = server_.getRegistry<Ability>().get(ability);
+    if (entry == nullptr) {
+        throw std::out_of_range("Ability is not available.");
+    }
+
+    const auto index = static_cast<const EndstoneAbility *>(entry)->getIndex();
+    const auto &value = getHandle().getAbilities().getAbility(index);
+    switch (value.getType()) {
+    case ::Ability::Type::Bool:
+        return value.getBool();
+    case ::Ability::Type::Float:
+        return value.getFloat();
+    case ::Ability::Type::Invalid:
+    case ::Ability::Type::Unset:
+        break;
+    }
+    throw std::runtime_error("Ability holds no value type.");
+}
+
+bool EndstonePlayer::_setAbility(const Identifier<Ability> ability, AbilityValue value)
+{
+    const auto *entry = server_.getRegistry<Ability>().get(ability);
+    if (entry == nullptr) {
+        return false;
+    }
+
+    const auto index = static_cast<const EndstoneAbility *>(entry)->getIndex();
+    auto &abilities = getHandle().getAbilities();
+    const auto expected = std::holds_alternative<bool>(value) ? ::Ability::Type::Bool : ::Ability::Type::Float;
+    if (abilities.getAbility(index).getType() != expected) {
+        return false;
+    }
+
+    std::visit([&abilities, index](auto &&v) { abilities.setAbility(index, v); }, value);
+    updateAbilities();
+    return true;
 }
 
 void EndstonePlayer::onFormClose(std::uint32_t form_id, PlayerFormCloseReason /*reason*/)

--- a/src/endstone/core/player.h
+++ b/src/endstone/core/player.h
@@ -128,6 +128,8 @@ public:
     void closeForm() override;
     void sendPacket(int packet_id, std::string_view payload) const override;
     void sendMap(MapView &map) override;
+    [[nodiscard]] AbilityValue _getAbility(Identifier<Ability> ability) const override;
+    bool _setAbility(Identifier<Ability> ability, AbilityValue value) override;
 
     void onFormClose(std::uint32_t form_id, PlayerFormCloseReason reason);
     void onFormResponse(std::uint32_t form_id, const nlohmann::json &json);

--- a/src/endstone/core/registry.cpp
+++ b/src/endstone/core/registry.cpp
@@ -26,6 +26,7 @@
 #include "bedrock/world/level/biome/biome.h"
 #include "bedrock/world/level/biome/registry/biome_registry.h"
 #include "bedrock/world/level/block/registry/block_type_registry.h"
+#include "endstone/core/ability.h"
 #include "endstone/core/actor/actor_type.h"
 #include "endstone/core/block/biome.h"
 #include "endstone/core/block/block_type.h"
@@ -37,6 +38,36 @@
 #include "endstone/core/server.h"
 
 namespace endstone::core {
+
+template <>
+std::vector<Identifier<Ability>> EndstoneRegistry<Ability, std::string>::identifiers() const
+{
+    std::vector<Identifier<Ability>> keys;
+    keys.reserve(EndstoneAbility::all().size());
+    for (const auto &entry : EndstoneAbility::all()) {
+        keys.emplace_back(entry.id);
+    }
+    return keys;
+}
+
+template <>
+const std::string *EndstoneRegistry<Ability, std::string>::getMinecraft(Identifier<Ability> id) const
+{
+    // cache is pre-populated, getMinecraft should not be called
+    return nullptr;
+}
+
+template <>
+std::unique_ptr<Registry<Ability>> EndstoneRegistry<Ability, std::string>::create()
+{
+    auto registry = std::make_unique<EndstoneRegistry>(
+        [](const auto &, const auto &) -> std::unique_ptr<Ability> { return nullptr; });
+
+    for (const auto &entry : EndstoneAbility::all()) {
+        registry->cache_.emplace(entry.id, std::make_unique<EndstoneAbility>(entry));
+    }
+    return registry;
+}
 
 template <>
 std::vector<Identifier<Enchantment>> EndstoneRegistry<Enchantment, Enchant>::identifiers() const

--- a/src/endstone/core/server.cpp
+++ b/src/endstone/core/server.cpp
@@ -285,6 +285,7 @@ void EndstoneServer::setLevel(::Level &level)
 
 void EndstoneServer::initRegistries()
 {
+    registries_[typeid(Ability)] = EndstoneRegistry<Ability, std::string>::create();
     registries_[typeid(ActorType)] = EndstoneRegistry<ActorType, std::string>::create();
     registries_[typeid(Biome)] = EndstoneRegistry<Biome, ::Biome>::create();
     registries_[typeid(BlockType)] = EndstoneRegistry<BlockType, ::BlockType>::create();

--- a/src/endstone/python/CMakeLists.txt
+++ b/src/endstone/python/CMakeLists.txt
@@ -5,6 +5,7 @@ set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 pybind11_add_module(_python MODULE
+        ability.cpp
         actor.cpp
         attribute.cpp
         ban.cpp

--- a/src/endstone/python/ability.cpp
+++ b/src/endstone/python/ability.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2024, The Endstone Project. (https://endstone.dev) All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "endstone_python.h"
+
+namespace py = pybind11;
+
+namespace endstone::python {
+void init_ability(py::module_ &m)
+{
+    def_registry_type(py::class_<Ability>(m, "Ability", R"doc(
+    All player abilities.
+
+    `ATTACK_MOBS`, `ATTACK_PLAYERS`, `BUILD`, `DOORS_AND_SWITCHES`, `MINE`, `OPEN_CONTAINERS`, `OPERATOR_COMMANDS`
+    and `TELEPORT` are the eight member permissions the client shows in its pause menu, and the server enforces
+    every one of them.
+)doc"))
+        .def_property_readonly("id", &Ability::getId, "The identifier of this ability.")
+        .def_property_readonly("translation_key", &Ability::getTranslationKey, "The translation key of this ability.")
+        .def_static("get", &Ability::get, py::arg("name"), R"doc(
+    Attempts to get the `Ability` with the given name.
+
+    Args:
+        name: The identifier of the ability (e.g. `minecraft:noclip`).
+
+    Returns:
+        The `Ability`, or `None` if no ability with that name exists.
+)doc",
+                    py::return_value_policy::reference)
+        .def_static(
+            "__class_getitem__", [](const py::object &) { return py::type::of<Ability>(); }, py::arg("item"))
+        .def_property_readonly_static("ATTACK_MOBS", id(Ability::AttackMobs), "Whether the player can attack mobs.")
+        .def_property_readonly_static("ATTACK_PLAYERS", id(Ability::AttackPlayers),
+                                      "Whether the player can attack other players.")
+        .def_property_readonly_static("BUILD", id(Ability::Build), "Whether the player can place blocks.")
+        .def_property_readonly_static("DOORS_AND_SWITCHES", id(Ability::DoorsAndSwitches),
+                                      "Whether the player can use doors, trapdoors, buttons, levers and other "
+                                      "redstone components.")
+        .def_property_readonly_static("FLYING", id(Ability::Flying), "Whether the player is currently flying.")
+        .def_property_readonly_static("FLY_SPEED", id(Ability::FlySpeed),
+                                      "The speed at which the player flies, default is ``0.05``.")
+        .def_property_readonly_static("INSTABUILD", id(Ability::Instabuild),
+                                      "Whether the player destroys blocks instantly.")
+        .def_property_readonly_static("INVULNERABLE", id(Ability::Invulnerable),
+                                      "Whether the player is immune to all damage.")
+        .def_property_readonly_static("LIGHTNING", id(Ability::Lightning),
+                                      "Whether the player was struck by lightning.")
+        .def_property_readonly_static("MAY_FLY", id(Ability::MayFly), "Whether the player is allowed to fly.")
+        .def_property_readonly_static("MINE", id(Ability::Mine), "Whether the player can destroy blocks.")
+        .def_property_readonly_static("MUTED", id(Ability::Muted),
+                                      "Whether the player's chat messages are hidden from other players.")
+        .def_property_readonly_static("NO_CLIP", id(Ability::NoClip), "Whether the player can move through blocks.")
+        .def_property_readonly_static("OPEN_CONTAINERS", id(Ability::OpenContainers),
+                                      "Whether the player can open containers.")
+        .def_property_readonly_static("OPERATOR_COMMANDS", id(Ability::OperatorCommands),
+                                      "Whether the player can use operator commands.")
+        .def_property_readonly_static("PRIVILEGED_BUILDER", id(Ability::PrivilegedBuilder),
+                                      "Whether the player is a privileged builder.")
+        .def_property_readonly_static("TELEPORT", id(Ability::Teleport), "Whether the player can teleport.")
+        .def_property_readonly_static("VERTICAL_FLY_SPEED", id(Ability::VerticalFlySpeed),
+                                      "The speed at which the player flies up and down, default is ``1``.")
+        .def_property_readonly_static("WALK_SPEED", id(Ability::WalkSpeed),
+                                      "The speed at which the player walks, default is ``0.1``.")
+        .def_property_readonly_static("WORLD_BUILDER", id(Ability::WorldBuilder),
+                                      "Whether the player is a world builder.");
+}
+}  // namespace endstone::python

--- a/src/endstone/python/endstone_python.cpp
+++ b/src/endstone/python/endstone_python.cpp
@@ -25,6 +25,7 @@
 #include "type_caster.h"
 
 namespace endstone::python {
+void init_ability(py::module_ &);
 void init_actor(py::module_ &, py_class<Actor> &actor, py_class<Mob> &mob);
 void init_attribute(py::module_ &);
 void init_ban(py::module_ &);
@@ -198,6 +199,7 @@ PYBIND11_MODULE(_python, m)  // NOLINT(*-use-anonymous-namespace)
     auto location =
         py::class_<Location>(m_level, "Location", "Represents a 3-dimensional location in a dimension within a level.");
 
+    init_ability(m);
     init_attribute(m_attribute);
     init_color_format(m);
     init_damage(m_damage);
@@ -845,6 +847,43 @@ void init_player(py::module_ &m, py_class<Player> &player)
     Args:
         packet_id: The packet ID to be sent.
         payload: The payload of the packet to be transmitted.
+)doc")
+        .def("get_ability", &Player::_getAbility, py::arg("ability"), R"doc(
+    Gets the value of an ability.
+
+    The value returned is the one in effect, which is not always the one that was set: while the player is
+    spectating, or has the loading screen up, or is in the editor, that state supplies its own value for some
+    abilities and it takes precedence over the player's own.
+
+    Args:
+        ability: The Minecraft ability to get.
+
+    Returns:
+        The current ability value.
+
+    Raises:
+        IndexError: If the ability does not exist.
+)doc")
+        .def(
+            "set_ability",
+            [](Player &self, Identifier<Ability> ability, AbilityValue value) {
+                if (!self._setAbility(ability, value)) {
+                    throw py::value_error(std::format("Unable to set ability {}.", ability));
+                }
+            },
+            py::arg("ability"), py::arg("value"), R"doc(
+    Sets the value of an ability.
+
+    Abilities are not persisted for a player whose permissions are managed by the server, so a plugin that wants a
+    value to outlast the session must set it again when the player rejoins. `Ability.MUTED`, `Ability.NO_CLIP`,
+    `Ability.PRIVILEGED_BUILDER` and `Ability.WORLD_BUILDER` are never saved at all.
+
+    Args:
+        ability: The Minecraft ability to set.
+        value: The new value, which must match the type of the ability.
+
+    Raises:
+        ValueError: If the ability does not exist or the value has the wrong type.
 )doc");
 }
 

--- a/src/endstone/python/stubgen.pat
+++ b/src/endstone/python/stubgen.pat
@@ -56,6 +56,44 @@
     def get_registry(self, type: type[_T]) -> Registry[_T]:
         \doc
 
+# Ability is generic in the value type, the same way GameRule is: bool for every
+# flag, float for the three speeds.
+^endstone\.Ability\.__bases__$:
+    typing.Generic[_T]
+
+^endstone\.Ability\.id$:
+    @property
+    def id(self) -> Identifier[Ability[_T]]:
+        \doc
+
+^endstone\.Ability\.get$:
+    @typing.overload
+    @staticmethod
+    def get(name: Identifier[Ability[_T]]) -> Ability[_T] | None: ...
+    @typing.overload
+    @staticmethod
+    def get(name: str) -> Ability[typing.Any] | None:
+        \doc
+
+^endstone\.Ability\.(?P<name>FLY_SPEED|VERTICAL_FLY_SPEED|WALK_SPEED)$:
+    \name: Identifier[Ability[float]] = \value
+^endstone\.Ability\.(?P<name>[A-Z][A-Z0-9_]*)$:
+    \name: Identifier[Ability[bool]] = \value
+
+^endstone\.Player\.get_ability$:
+    @typing.overload
+    def get_ability(self, ability: Identifier[Ability[_T]]) -> _T: ...
+    @typing.overload
+    def get_ability(self, ability: str) -> bool | float:
+        \doc
+
+^endstone\.Player\.set_ability$:
+    @typing.overload
+    def set_ability(self, ability: Identifier[Ability[_T]], value: _T) -> None: ...
+    @typing.overload
+    def set_ability(self, ability: str, value: bool | float) -> None:
+        \doc
+
 # GameRule is generic in the value type, which nothing carries at runtime -- a
 # constant is just its identifier there. Only the base is injected, so the class
 # body still generates; the int-valued rules are listed because the value type

--- a/tests/plugin/src/endstone_test/tests/player/test_ability.py
+++ b/tests/plugin/src/endstone_test/tests/player/test_ability.py
@@ -1,0 +1,133 @@
+import pytest
+from endstone import Ability, Player, Server
+
+BOOL_ABILITY = Ability.NO_CLIP
+FLOAT_ABILITY = Ability.FLY_SPEED
+
+# The eight the client shows in its pause menu.
+MEMBER_PERMISSIONS = [
+    Ability.BUILD,
+    Ability.MINE,
+    Ability.DOORS_AND_SWITCHES,
+    Ability.OPEN_CONTAINERS,
+    Ability.ATTACK_PLAYERS,
+    Ability.ATTACK_MOBS,
+    Ability.OPERATOR_COMMANDS,
+    Ability.TELEPORT,
+]
+
+
+@pytest.fixture(scope="function", autouse=True)
+def restore_abilities(player: Player):
+    touched = [BOOL_ABILITY, FLOAT_ABILITY, Ability.VERTICAL_FLY_SPEED, *MEMBER_PERMISSIONS]
+    saved = {ability: player.get_ability(ability) for ability in touched}
+
+    yield
+
+    for ability, value in saved.items():
+        player.set_ability(ability, value)
+
+
+# =============================================================================
+# Presence and value types
+# =============================================================================
+
+
+def test_value_types(player: Player) -> None:
+    """A flag reads as bool, a speed as float."""
+    assert isinstance(player.get_ability(BOOL_ABILITY), bool)
+    value = player.get_ability(FLOAT_ABILITY)
+    assert isinstance(value, float) and not isinstance(value, bool)
+
+
+def test_every_registered_ability_is_readable(server: Server, player: Player) -> None:
+    """Reading any ability in the registry yields a value of the right kind."""
+    registry = server.get_registry(Ability)
+    assert len(registry) == 20
+
+    for ability in registry:
+        assert isinstance(player.get_ability(ability.id), (bool, float))
+
+
+# =============================================================================
+# Round trips
+# =============================================================================
+
+
+def test_bool_round_trip(player: Player) -> None:
+    """Writing a flag twice through the API lands both times."""
+    original = player.get_ability(BOOL_ABILITY)
+
+    player.set_ability(BOOL_ABILITY, not original)
+    assert player.get_ability(BOOL_ABILITY) is (not original)
+
+    player.set_ability(BOOL_ABILITY, original)
+    assert player.get_ability(BOOL_ABILITY) is original
+
+
+def test_float_round_trip(player: Player) -> None:
+    """A speed survives a write and read back."""
+    player.set_ability(FLOAT_ABILITY, 0.15)
+    assert player.get_ability(FLOAT_ABILITY) == pytest.approx(0.15)
+
+    player.set_ability(Ability.VERTICAL_FLY_SPEED, 2.0)
+    assert player.get_ability(Ability.VERTICAL_FLY_SPEED) == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize("ability", MEMBER_PERMISSIONS, ids=lambda a: a.key)
+def test_member_permission_round_trip(player: Player, ability) -> None:
+    """Each pause-menu member permission can be flipped and read back."""
+    original = player.get_ability(ability)
+
+    player.set_ability(ability, not original)
+    assert player.get_ability(ability) is (not original)
+
+    player.set_ability(ability, original)
+    assert player.get_ability(ability) is original
+
+
+def test_fly_speed_matches_legacy_accessor(player: Player) -> None:
+    """The keyed API and the dedicated fly_speed property address the same ability."""
+    player.set_ability(FLOAT_ABILITY, 0.2)
+    assert player.fly_speed == pytest.approx(0.2)
+
+    player.fly_speed = 0.05
+    assert player.get_ability(FLOAT_ABILITY) == pytest.approx(0.05)
+
+
+def test_set_does_not_disturb_other_abilities(server: Server, player: Player) -> None:
+    """Setting one ability leaves every other ability alone."""
+    names = [str(ability.id) for ability in server.get_registry(Ability)]
+    before = {name: player.get_ability(name) for name in names}
+
+    target = str(BOOL_ABILITY)
+    player.set_ability(BOOL_ABILITY, not before[target])
+
+    after = {name: player.get_ability(name) for name in names}
+    changed = {name for name in names if after[name] != before[name]}
+    assert changed == {target}
+
+
+# =============================================================================
+# Failure modes
+# =============================================================================
+
+
+def test_get_unknown_ability_raises(player: Player) -> None:
+    """Reading an ability that does not exist raises rather than returning a default."""
+    with pytest.raises(IndexError):
+        player.get_ability("minecraft:not_an_ability")
+
+
+def test_set_unknown_ability_raises(player: Player) -> None:
+    """Writing an ability that does not exist raises."""
+    with pytest.raises(ValueError):
+        player.set_ability("minecraft:not_an_ability", True)
+
+
+def test_set_wrong_value_type_raises(player: Player) -> None:
+    """A value whose type does not match the ability is rejected."""
+    with pytest.raises(ValueError):
+        player.set_ability(FLOAT_ABILITY, True)
+    with pytest.raises(ValueError):
+        player.set_ability(BOOL_ABILITY, 0.5)

--- a/tests/plugin/src/endstone_test/tests/test_registry.py
+++ b/tests/plugin/src/endstone_test/tests/test_registry.py
@@ -1,5 +1,5 @@
 import pytest
-from endstone import GameRule, Identifier, Server
+from endstone import Ability, GameRule, Identifier, Server
 from endstone.actor import ActorType
 from endstone.attribute import Attribute
 from endstone.block import Biome, BlockType
@@ -9,6 +9,7 @@ from endstone.potion import EffectType, PotionType
 
 # All registry types to test generically
 REGISTRY_TYPES = [
+    Ability,
     ActorType,
     Biome,
     BlockType,
@@ -26,6 +27,7 @@ UNLOCALIZED_REGISTRY_TYPES = [
 ]
 
 FULLY_EXPORTED_REGISTRY_TYPES = [
+    Ability,
     ActorType,
     EffectType,
     Enchantment,


### PR DESCRIPTION
Adds a keyed, type-safe player ability API, shaped after the existing `GameRule` API.

Supersedes #319 and closes #296.

## Why keyed instead of accessors

#319 proposed `getNoClip`/`setNoClip` and `getVerticalFlySpeed`/`setVerticalFlySpeed` — four new pure
virtuals for two abilities. Bedrock has twenty, so that shape costs two vtable slots every time one more
is wanted. #296 asks for eight more of them (the pause-menu member permissions), which under that shape
would be sixteen further pure virtuals.

Neither has a Bukkit counterpart to copy: Paper's `Player` has no vertical fly speed and no
noclip/collision method, and `@minecraft/server` cannot read or write abilities at all. The two Bedrock
servers that do ship this went keyed or renamed — Nukkit exposes `AdventureSettings.Type.NO_CLIP`
through a generic `set(Type, bool)`, and PocketMine renamed noclip to `setHasBlockCollision` during
review. So there is no name to be faithful to, and the shape is ours to choose.

This takes the `GameRule` route instead: one identifier per ability, carrying its own value type, behind
**three** new pure virtuals total (`_getAbility`, `_setAbility`, appended at the end of `Player`), and
the vtable never grows again when Mojang adds ability twenty-one.

## Usage

```cpp
bool noclip = player.getAbility(Ability::NoClip);
player.setAbility(Ability::NoClip, true);

float speed = player.getAbility(Ability::FlySpeed);
player.setAbility(Ability::FlySpeed, 0.15F);

player.setAbility(Ability::NoClip, 0.15F);   // compile error
player.setAbility(Ability::FlySpeed, true);  // compile error
```

The type check is a template deduction conflict on `setAbility(AbilityId<T>, T)`, exactly as
`setGameRule` already does it — verified against clang-cl 22.1.3 with `/std:c++20`, both good cases
compiling and both bad ones failing to. `getAbility` returns `T`, so `bool b = getAbility(Ability::FlySpeed)`
narrows at the assignment rather than at the call, same as `getGameRule`.

```python
player.set_ability(Ability.NO_CLIP, True)
player.set_ability(Ability.FLY_SPEED, 0.15)

for ability in server.get_registry(Ability):
    print(ability.id, player.get_ability(ability.id))
```

Python gets the same narrowing statically, through the overloads `stubgen.pat` injects:
`get_ability(Identifier[Ability[_T]]) -> _T`.

## What it closes

**#319** — `Ability::NoClip` and `Ability::VerticalFlySpeed` are both in the set. Both are genuinely
enforced server-side rather than being client cosmetics: the abilities component feeds
`UpdateAbilitiesSystem`, which drives `MovementAbilitiesComponent`, which reaches
`NoClipOrNoBlockMoveFilterSystem` for noclip and `VerticalFlySpeedControlSystem` for the vertical speed.

**#296** — the eight toggles in the client's pause menu are exactly the abilities Bedrock marks
`PermissionsInterfaceExposed`, and all eight are here: `Build`, `Mine`, `DoorsAndSwitches`,
`OpenContainers`, `AttackPlayers`, `AttackMobs`, `OperatorCommands`, `Teleport`. Every one is enforced
by the server through `Player::canUseAbility`, so setting them changes behaviour and not just what the
menu draws.

The `/tp` case the issue calls out is the clearest example. `MinecraftCommandWrapper::run` lowers the
vanilla registry permission to `Any` so Endstone permission nodes decide, but `TeleportCommand::execute`
makes its own in-body `canUseAbility(Teleport)` check that the bypass never sees — which is why granting
an Endstone node for `/tp` still failed. Setting the Teleport ability is the only thing that fixes it.

## Design notes

`Ability` is a registry type (`Registry<Ability>::Type`), not just a constant holder, so it can be
enumerated and looked up like every other registry — the same pre-populated, non-Minecraft-backed shape
`ActorType` already uses (`EndstoneRegistry<Ability, std::string>`, cache filled in `create()`,
`getMinecraft` returning `nullptr`). This is Bukkit's `Registry.SimpleRegistry` idea: a fixed, closed set
exposed through the normal registry surface. `translation_key` is `permissions.ability.<key>`; the
server's own vanilla pack ships a translation for the eight member permissions, and the rest form a key
that simply has no entry.

Constants are `CamelCase` in C++ and `UPPER_CASE` in Python, matching `GameRule`/`Attribute`/`Dimension`.
Identifier keys are all-lowercase (`minecraft:flyspeed`, `minecraft:verticalflyspeed`) for consistency
with the other identifiers in the API, even where Bedrock's internal name is camelCase.

`endstone::Ability` shares a name with the bedrock `::Ability`, which core code qualifies — the same
arrangement `endstone::GameRule`/`::GameRule` and `endstone::BlockType`/`::BlockType` already live with.

## Behaviour worth knowing

- **Reads are the effective value, writes are the player's own.** Bedrock layers abilities; reading
  resolves the topmost layer that has one set, writing goes to the base layer. Spectator mode, the
  editor and the loading screen each supply their own values for some abilities, so a spectator reads
  back `NoClip` as true regardless. This mirrors vanilla: the pause-menu handler writes the base layer
  too. Documented on both methods.
- **Persistence.** `Muted`, `WorldBuilder`, `NoClip` and `PrivilegedBuilder` are never saved by Bedrock.
  The other sixteen are saved, but a player whose permissions the server manages has all eight member
  permissions re-derived on join, so plugins should reapply on rejoin.
- **Not covered:** `PlayerPermissionLevel`. Vanilla couples it to the eight member permissions in both
  directions, and `Player::canUseOperatorBlocks` wants `CommandPermissionLevel` and `Instabuild` on top
  of `OperatorCommands`. So `setAbility(Ability::OperatorCommands, true)` is not `setOp`. Exposing the
  permission level is a separate change and needs a BDS symbol this PR does not add.

The existing `fly_speed`, `walk_speed`, `allow_flight` and `is_flying` accessors are unchanged; they
address the same abilities, and there is a test asserting the two agree.

## Verification

The ability table (index, value type, default, option bits) was read out of the server binary rather
than guessed: `Abilities::ABILITY_NAMES` for the twenty identifier keys and
`Abilities::_initDefaultAbilities` for the types, defaults and the `PermissionsInterfaceExposed` bits.
Exactly indices 0–7 carry that bit, and exactly `FlySpeed`, `WalkSpeed` and `VerticalFlySpeed` are
floats.

Runtime coverage in `tests/plugin/.../player/test_ability.py`: value types, round trips for a flag, both
speeds and each of the eight member permissions, agreement with the legacy `fly_speed` property,
isolation (setting one ability disturbs no other), and the three failure modes (unknown id on read and
write, wrong value type). `Ability` is also added to the generic `test_registry.py` parametrisations.
